### PR TITLE
feat: build the GitHub API client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ analysis records the `scoringVersion` it was produced under.
 
 ### Added
 
+- GitHub API client: a typed `fetch` wrapper with bearer auth, per-request
+  timeouts, bounded jittered retry on 5xx and network errors only, rate-limit
+  accounting with reset times, ETag conditional requests, a hard per-analysis
+  request budget, and truncation-aware pagination
 - Repository input validation: a Zod-backed parser that accepts `owner/repo`,
   GitHub URLs, deep links, and `git@` remotes, and rejects everything else.
   This is the SSRF boundary — only a validated `{ owner, name }` pair reaches

--- a/src/lib/github/client.ts
+++ b/src/lib/github/client.ts
@@ -1,0 +1,401 @@
+import { GitHubError, RateLimitError } from './errors';
+import { RequestBudget } from './request-budget';
+
+/**
+ * The only host RepoSignal ever contacts.
+ *
+ * Requests are built by joining validated path components onto this constant.
+ * No user-supplied string is ever used as a URL, and redirects away from this
+ * host are not followed. Together with the input validation in
+ * `src/lib/validation/repository-reference.ts`, this is the SSRF boundary.
+ */
+const API_BASE = 'https://api.github.com';
+
+const DEFAULT_TIMEOUT_MS = 10_000;
+const DEFAULT_MAX_RETRIES = 2;
+const DEFAULT_BUDGET = 40;
+
+/**
+ * Statuses that mean "go somewhere else". Deliberately enumerated rather than
+ * checked as a 3xx range, because 304 Not Modified shares that range and is a
+ * cache validation result, not a redirect.
+ */
+const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
+
+/** GitHub asks for an explicit API version and a descriptive user agent. */
+const BASE_HEADERS: Record<string, string> = {
+  Accept: 'application/vnd.github+json',
+  'X-GitHub-Api-Version': '2022-11-28',
+  'User-Agent': 'RepoSignal (+https://github.com/mateoosoriodelhonte/reposignal)',
+};
+
+export interface RateLimitState {
+  remaining: number | null;
+  limit: number | null;
+  resetAt: Date | null;
+}
+
+export interface GitHubResponse<T> {
+  data: T;
+  status: number;
+  /** Parsed `link` header relations, e.g. `{ next: '...' }`. */
+  links: Record<string, string>;
+  etag: string | null;
+}
+
+export interface GitHubClientOptions {
+  token?: string | undefined;
+  timeoutMs?: number;
+  maxRetries?: number;
+  budget?: RequestBudget;
+  /** Injected for tests. Defaults to the global `fetch`. */
+  fetchImpl?: typeof fetch;
+  /** Injected so retry backoff is instant in tests. */
+  sleep?: (ms: number) => Promise<void>;
+  /** Injected so jitter is deterministic in tests. */
+  random?: () => number;
+}
+
+export interface RequestOptions {
+  /** Path relative to the API base, e.g. `repos/facebook/react`. */
+  path: string;
+  searchParams?: Record<string, string | number>;
+  /** Sent as `If-None-Match` so an unchanged resource costs no rate limit. */
+  etag?: string | null;
+  /** Override the default Accept header, e.g. for raw file contents. */
+  accept?: string;
+  signal?: AbortSignal;
+}
+
+function defaultSleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Parses a `Link` header into its relations.
+ *
+ * Only `rel` values are extracted; the URLs are used for pagination detection
+ * rather than being fetched directly, so a malicious `Link` cannot redirect
+ * collection off GitHub.
+ */
+export function parseLinkHeader(header: string | null): Record<string, string> {
+  if (!header) return {};
+
+  const links: Record<string, string> = {};
+  for (const part of header.split(',')) {
+    const match = /<([^>]+)>\s*;\s*rel="([^"]+)"/.exec(part.trim());
+    if (match?.[1] !== undefined && match[2] !== undefined) {
+      links[match[2]] = match[1];
+    }
+  }
+  return links;
+}
+
+function parseRateLimit(headers: Headers): RateLimitState {
+  const remaining = headers.get('x-ratelimit-remaining');
+  const limit = headers.get('x-ratelimit-limit');
+  const reset = headers.get('x-ratelimit-reset');
+
+  return {
+    remaining: remaining === null ? null : Number.parseInt(remaining, 10),
+    limit: limit === null ? null : Number.parseInt(limit, 10),
+    resetAt: reset === null ? null : new Date(Number.parseInt(reset, 10) * 1000),
+  };
+}
+
+/**
+ * A thin, typed client over `fetch`.
+ *
+ * It exists instead of Octokit because RepoSignal needs policies that are
+ * awkward to express on top of a general-purpose client: a hard per-analysis
+ * request budget, sample truncation surfaced to the caller rather than hidden,
+ * and rate-limit handling that fails fast with a reset time instead of
+ * retrying into the limit.
+ */
+export class GitHubClient {
+  readonly budget: RequestBudget;
+  #token: string | undefined;
+  #timeoutMs: number;
+  #maxRetries: number;
+  #fetch: typeof fetch;
+  #sleep: (ms: number) => Promise<void>;
+  #random: () => number;
+  #rateLimit: RateLimitState = { remaining: null, limit: null, resetAt: null };
+
+  constructor(options: GitHubClientOptions = {}) {
+    this.#token = options.token ?? process.env.GITHUB_TOKEN;
+    this.#timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    this.#maxRetries = options.maxRetries ?? DEFAULT_MAX_RETRIES;
+    this.budget = options.budget ?? new RequestBudget(DEFAULT_BUDGET);
+    this.#fetch = options.fetchImpl ?? globalThis.fetch;
+    this.#sleep = options.sleep ?? defaultSleep;
+    this.#random = options.random ?? Math.random;
+  }
+
+  /** The most recent rate-limit state GitHub reported. */
+  get rateLimit(): RateLimitState {
+    return this.#rateLimit;
+  }
+
+  #buildUrl(path: string, searchParams?: Record<string, string | number>): string {
+    // Reject anything that could escape the API base. Callers pass fixed
+    // path templates with validated components interpolated, so a `..` or a
+    // scheme here means a bug upstream, not a legitimate request.
+    if (path.includes('..') || path.includes('//') || /^[a-z]+:/i.test(path)) {
+      throw new GitHubError('unexpected', 'Refusing to build a request from that path.', {
+        resource: path,
+      });
+    }
+
+    const url = new URL(`${API_BASE}/${path.replace(/^\//, '')}`);
+
+    if (url.origin !== API_BASE) {
+      throw new GitHubError('unexpected', 'Refusing to request a non-GitHub origin.', {
+        resource: path,
+      });
+    }
+
+    for (const [key, value] of Object.entries(searchParams ?? {})) {
+      url.searchParams.set(key, String(value));
+    }
+    return url.toString();
+  }
+
+  #headers(options: RequestOptions): Headers {
+    const headers = new Headers(BASE_HEADERS);
+    if (options.accept !== undefined) headers.set('Accept', options.accept);
+    if (this.#token) headers.set('Authorization', `Bearer ${this.#token}`);
+    if (options.etag) headers.set('If-None-Match', options.etag);
+    return headers;
+  }
+
+  /**
+   * Retry delay with full jitter.
+   *
+   * Jitter matters more than the base delay here: without it, several
+   * concurrent analyses that hit a 5xx together would retry in lockstep and
+   * hit GitHub again simultaneously.
+   */
+  #backoffMs(attempt: number): number {
+    const base = Math.min(1000 * 2 ** attempt, 8000);
+    return Math.floor(base * (0.5 + this.#random() * 0.5));
+  }
+
+  /**
+   * Performs one GitHub request.
+   *
+   * Returns `null` data on `304 Not Modified`, which is how the caller learns
+   * its cached copy is still current. A `304` costs no rate limit, which is
+   * the entire reason ETags are threaded through.
+   */
+  async request<T>(options: RequestOptions): Promise<GitHubResponse<T | null>> {
+    if (!this.budget.tryConsume()) {
+      throw new GitHubError(
+        'budget_exhausted',
+        'This analysis reached its GitHub request budget.',
+        { resource: options.path },
+      );
+    }
+
+    const url = this.#buildUrl(options.path, options.searchParams);
+    let lastError: unknown;
+
+    for (let attempt = 0; attempt <= this.#maxRetries; attempt += 1) {
+      const timeout = AbortSignal.timeout(this.#timeoutMs);
+      const signal = options.signal
+        ? AbortSignal.any([options.signal, timeout])
+        : timeout;
+
+      let response: Response;
+      try {
+        response = await this.#fetch(url, {
+          method: 'GET',
+          headers: this.#headers(options),
+          signal,
+          // A redirect off api.github.com would defeat the SSRF boundary, so
+          // it is surfaced as an error rather than followed.
+          redirect: 'manual',
+        });
+      } catch (cause) {
+        // A caller-initiated abort is not a transient fault; do not retry it.
+        if (options.signal?.aborted) {
+          throw new GitHubError('timeout', 'The request was cancelled.', {
+            resource: options.path,
+            cause,
+          });
+        }
+
+        lastError = cause;
+        if (attempt < this.#maxRetries) {
+          await this.#sleep(this.#backoffMs(attempt));
+          continue;
+        }
+
+        const timedOut = cause instanceof Error && cause.name === 'TimeoutError';
+        throw new GitHubError(
+          timedOut ? 'timeout' : 'network',
+          timedOut ? 'GitHub did not respond in time.' : 'Could not reach GitHub.',
+          { resource: options.path, cause },
+        );
+      }
+
+      this.#rateLimit = parseRateLimit(response.headers);
+
+      // 304 is checked before the redirect guard below: it shares the 3xx
+      // range but is a cache validation result, not a redirect.
+      if (response.status === 304) {
+        return {
+          data: null,
+          status: 304,
+          links: parseLinkHeader(response.headers.get('link')),
+          etag: response.headers.get('etag'),
+        };
+      }
+
+      if (REDIRECT_STATUSES.has(response.status)) {
+        throw new GitHubError('unexpected', 'GitHub redirected the request.', {
+          status: response.status,
+          resource: options.path,
+        });
+      }
+
+      if (response.ok) {
+        let data: T;
+        try {
+          data = (await response.json()) as T;
+        } catch (cause) {
+          throw new GitHubError('invalid_response', 'GitHub returned malformed JSON.', {
+            status: response.status,
+            resource: options.path,
+            cause,
+          });
+        }
+
+        return {
+          data,
+          status: response.status,
+          links: parseLinkHeader(response.headers.get('link')),
+          etag: response.headers.get('etag'),
+        };
+      }
+
+      // Retry server errors only. A 4xx will not become a 2xx by asking again.
+      if (response.status >= 500 && attempt < this.#maxRetries) {
+        await this.#sleep(this.#backoffMs(attempt));
+        continue;
+      }
+
+      throw this.#toError(response, options.path);
+    }
+
+    /* c8 ignore next 4 -- unreachable: the loop returns or throws every path */
+    throw new GitHubError('unexpected', 'GitHub request failed.', {
+      resource: options.path,
+      cause: lastError,
+    });
+  }
+
+  #toError(response: Response, resource: string): GitHubError {
+    const { status, headers } = response;
+    const remaining = headers.get('x-ratelimit-remaining');
+    const retryAfter = headers.get('retry-after');
+
+    // GitHub signals the primary rate limit as 403/429 with remaining=0, and
+    // the secondary (abuse) limit as 403/429 with a retry-after header.
+    if (status === 429 || (status === 403 && (remaining === '0' || retryAfter))) {
+      const isSecondary = remaining !== '0';
+      let resetAt = this.#rateLimit.resetAt;
+
+      if (retryAfter !== null) {
+        const seconds = Number.parseInt(retryAfter, 10);
+        if (Number.isFinite(seconds)) {
+          resetAt = new Date(Date.now() + seconds * 1000);
+        }
+      }
+
+      return new RateLimitError(
+        isSecondary
+          ? 'GitHub is temporarily throttling requests.'
+          : 'GitHub API rate limit reached.',
+        { resetAt, isSecondary, status, resource },
+      );
+    }
+
+    switch (status) {
+      case 404:
+        return new GitHubError('not_found', 'That repository could not be found.', {
+          status,
+          resource,
+        });
+      case 401:
+        return new GitHubError('forbidden', 'GitHub rejected the credentials.', {
+          status,
+          resource,
+        });
+      case 403:
+        return new GitHubError('forbidden', 'GitHub denied access to that resource.', {
+          status,
+          resource,
+        });
+      case 451:
+        return new GitHubError(
+          'forbidden',
+          'That repository is unavailable for legal reasons.',
+          {
+            status,
+            resource,
+          },
+        );
+      default:
+        return new GitHubError('unexpected', `GitHub returned an unexpected status.`, {
+          status,
+          resource,
+        });
+    }
+  }
+
+  /**
+   * Fetches up to `maxItems` records, following pagination.
+   *
+   * Returns what it collected plus whether more exists, so the caller can
+   * record the truncation on the snapshot and lower confidence accordingly.
+   * Stopping quietly at a page boundary and reporting the result as complete
+   * is the failure mode this signature exists to prevent.
+   */
+  async paginate<T>(
+    options: RequestOptions & { maxItems: number; perPage?: number },
+  ): Promise<{ items: T[]; truncated: boolean }> {
+    const perPage = Math.min(options.perPage ?? 100, 100);
+    const items: T[] = [];
+    let page = 1;
+
+    while (items.length < options.maxItems) {
+      if (this.budget.exhausted) {
+        return { items, truncated: true };
+      }
+
+      const response = await this.request<T[]>({
+        ...options,
+        searchParams: {
+          ...options.searchParams,
+          per_page: perPage,
+          page,
+        },
+      });
+
+      const batch = response.data;
+      if (!Array.isArray(batch) || batch.length === 0) {
+        return { items, truncated: false };
+      }
+
+      items.push(...batch);
+
+      if (response.links['next'] === undefined) {
+        return { items, truncated: false };
+      }
+      page += 1;
+    }
+
+    return { items: items.slice(0, options.maxItems), truncated: true };
+  }
+}

--- a/src/lib/github/errors.ts
+++ b/src/lib/github/errors.ts
@@ -1,0 +1,80 @@
+/**
+ * Typed errors for everything that can go wrong talking to GitHub.
+ *
+ * Callers switch on `kind` rather than parsing messages, and the analysis
+ * layer maps each kind to a distinct user-facing explanation. A generic
+ * "something went wrong" is the failure this taxonomy exists to prevent.
+ *
+ * No error carries a token, an authorization header, or a raw response body.
+ */
+
+export type GitHubErrorKind =
+  | 'not_found'
+  | 'rate_limited'
+  | 'forbidden'
+  | 'timeout'
+  | 'network'
+  | 'budget_exhausted'
+  | 'invalid_response'
+  | 'unexpected';
+
+export class GitHubError extends Error {
+  readonly kind: GitHubErrorKind;
+  /** HTTP status, when the failure came from a response. */
+  readonly status?: number;
+  /** The resource being requested, e.g. `repos/facebook/react`. Never a URL
+   *  with credentials, and never the token. */
+  readonly resource?: string;
+
+  constructor(
+    kind: GitHubErrorKind,
+    message: string,
+    options: { status?: number; resource?: string; cause?: unknown } = {},
+  ) {
+    super(message, options.cause === undefined ? undefined : { cause: options.cause });
+    this.name = 'GitHubError';
+    this.kind = kind;
+    if (options.status !== undefined) this.status = options.status;
+    if (options.resource !== undefined) this.resource = options.resource;
+  }
+}
+
+/**
+ * Raised when GitHub's rate limit is reached.
+ *
+ * `resetAt` is what lets the UI say when access returns instead of asking the
+ * user to try again vaguely later. RepoSignal does not retry into a rate
+ * limit — waiting out a limit inside a request handler just converts a fast
+ * failure into a slow one.
+ */
+export class RateLimitError extends GitHubError {
+  readonly resetAt: Date | null;
+  /** True for the secondary (abuse) limit, which has no fixed reset time. */
+  readonly isSecondary: boolean;
+
+  constructor(
+    message: string,
+    options: {
+      resetAt?: Date | null;
+      isSecondary?: boolean;
+      status?: number;
+      resource?: string;
+    } = {},
+  ) {
+    super('rate_limited', message, {
+      ...(options.status === undefined ? {} : { status: options.status }),
+      ...(options.resource === undefined ? {} : { resource: options.resource }),
+    });
+    this.name = 'RateLimitError';
+    this.resetAt = options.resetAt ?? null;
+    this.isSecondary = options.isSecondary ?? false;
+  }
+}
+
+export function isGitHubError(error: unknown): error is GitHubError {
+  return error instanceof GitHubError;
+}
+
+export function isRateLimitError(error: unknown): error is RateLimitError {
+  return error instanceof RateLimitError;
+}

--- a/src/lib/github/request-budget.ts
+++ b/src/lib/github/request-budget.ts
@@ -1,0 +1,45 @@
+/**
+ * A hard cap on the GitHub requests a single analysis may spend.
+ *
+ * Without one, a repository with 8,000 open issues would happily paginate
+ * until the rate limit is gone and every other user is locked out. The budget
+ * makes the cost of an analysis bounded and predictable.
+ *
+ * Exhausting the budget is not an error. It means the analysis proceeds with
+ * the data it has, records that its samples were truncated, and lowers the
+ * confidence of anything derived from them. That is the honest outcome —
+ * failing outright would discard good partial data.
+ */
+export class RequestBudget {
+  readonly limit: number;
+  #spent = 0;
+
+  constructor(limit: number) {
+    if (!Number.isInteger(limit) || limit < 1) {
+      throw new RangeError('Request budget must be a positive integer.');
+    }
+    this.limit = limit;
+  }
+
+  get spent(): number {
+    return this.#spent;
+  }
+
+  get remaining(): number {
+    return Math.max(0, this.limit - this.#spent);
+  }
+
+  get exhausted(): boolean {
+    return this.#spent >= this.limit;
+  }
+
+  /**
+   * Reserves one request. Returns false when the budget is spent, so callers
+   * stop paginating rather than throwing mid-collection.
+   */
+  tryConsume(): boolean {
+    if (this.exhausted) return false;
+    this.#spent += 1;
+    return true;
+  }
+}

--- a/tests/unit/github/client.test.ts
+++ b/tests/unit/github/client.test.ts
@@ -1,0 +1,464 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { GitHubClient, parseLinkHeader } from '@/lib/github/client';
+import { GitHubError, RateLimitError, isRateLimitError } from '@/lib/github/errors';
+import { RequestBudget } from '@/lib/github/request-budget';
+
+const TOKEN = 'ghp_thisIsTheSecretThatMustNeverLeak';
+
+/** Builds a client whose transport, clock, and jitter are all deterministic. */
+function makeClient(
+  responses: Array<Response | Error>,
+  overrides: Partial<ConstructorParameters<typeof GitHubClient>[0]> = {},
+) {
+  const calls: Array<{ url: string; init: RequestInit }> = [];
+  let index = 0;
+
+  const fetchImpl = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+    calls.push({ url: String(url), init: init ?? {} });
+    const next = responses[Math.min(index, responses.length - 1)];
+    index += 1;
+    if (next instanceof Error) throw next;
+    if (next === undefined) throw new Error('No response configured');
+    // A Response body can only be read once. The last configured response is
+    // reused for any extra calls, so hand out a clone rather than the original.
+    return next.clone();
+  }) as unknown as typeof fetch;
+
+  const client = new GitHubClient({
+    token: TOKEN,
+    fetchImpl,
+    sleep: async () => {},
+    random: () => 0.5,
+    ...overrides,
+  });
+
+  return { client, calls, fetchImpl };
+}
+
+function json(
+  body: unknown,
+  init: { status?: number; headers?: Record<string, string> } = {},
+) {
+  return new Response(JSON.stringify(body), {
+    status: init.status ?? 200,
+    headers: { 'content-type': 'application/json', ...init.headers },
+  });
+}
+
+describe('parseLinkHeader', () => {
+  it('returns an empty object for a missing header', () => {
+    expect(parseLinkHeader(null)).toEqual({});
+  });
+
+  it('extracts each relation', () => {
+    const header =
+      '<https://api.github.com/repos/a/b/issues?page=2>; rel="next", ' +
+      '<https://api.github.com/repos/a/b/issues?page=9>; rel="last"';
+    expect(parseLinkHeader(header)).toEqual({
+      next: 'https://api.github.com/repos/a/b/issues?page=2',
+      last: 'https://api.github.com/repos/a/b/issues?page=9',
+    });
+  });
+
+  it('ignores malformed entries rather than throwing', () => {
+    expect(parseLinkHeader('garbage; rel=')).toEqual({});
+  });
+});
+
+describe('GitHubClient request construction', () => {
+  it('builds URLs against api.github.com only', async () => {
+    const { client, calls } = makeClient([json({ id: 1 })]);
+    await client.request({ path: 'repos/facebook/react' });
+    expect(calls[0]?.url).toBe('https://api.github.com/repos/facebook/react');
+  });
+
+  it.each([
+    ['traversal', 'repos/../../admin'],
+    ['double slash', 'repos//evil'],
+    ['an absolute url', 'https://evil.com/repos/a/b'],
+    ['a protocol', 'file:///etc/passwd'],
+  ])('refuses to build a request from %s', async (_label, path) => {
+    const { client, fetchImpl } = makeClient([json({})]);
+    await expect(client.request({ path })).rejects.toThrow(GitHubError);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('appends search parameters', async () => {
+    const { client, calls } = makeClient([json([])]);
+    await client.request({
+      path: 'repos/a/b/issues',
+      searchParams: { state: 'open', per_page: 100 },
+    });
+    expect(calls[0]?.url).toContain('state=open');
+    expect(calls[0]?.url).toContain('per_page=100');
+  });
+
+  it('sends the API version and an identifying user agent', async () => {
+    const { client, calls } = makeClient([json({})]);
+    await client.request({ path: 'repos/a/b' });
+    const headers = new Headers(calls[0]?.init.headers);
+    expect(headers.get('x-github-api-version')).toBe('2022-11-28');
+    expect(headers.get('user-agent')).toContain('RepoSignal');
+  });
+
+  it('sends If-None-Match when given an etag', async () => {
+    const { client, calls } = makeClient([json({})]);
+    await client.request({ path: 'repos/a/b', etag: 'W/"abc"' });
+    expect(new Headers(calls[0]?.init.headers).get('if-none-match')).toBe('W/"abc"');
+  });
+
+  it('does not follow redirects, which would escape the API host', async () => {
+    const { client } = makeClient([
+      new Response(null, { status: 302, headers: { location: 'https://evil.com' } }),
+    ]);
+    await expect(client.request({ path: 'repos/a/b' })).rejects.toMatchObject({
+      kind: 'unexpected',
+    });
+  });
+});
+
+describe('GitHubClient responses', () => {
+  it('returns parsed data and the etag', async () => {
+    const { client } = makeClient([json({ id: 7 }, { headers: { etag: 'W/"x"' } })]);
+    const response = await client.request<{ id: number }>({ path: 'repos/a/b' });
+    expect(response.data).toEqual({ id: 7 });
+    expect(response.etag).toBe('W/"x"');
+  });
+
+  it('returns null data for 304, so callers know their cache is current', async () => {
+    const { client } = makeClient([new Response(null, { status: 304 })]);
+    const response = await client.request({ path: 'repos/a/b' });
+    expect(response.status).toBe(304);
+    expect(response.data).toBeNull();
+  });
+
+  it('raises invalid_response for malformed JSON', async () => {
+    const { client } = makeClient([
+      new Response('{not json', {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    ]);
+    await expect(client.request({ path: 'repos/a/b' })).rejects.toMatchObject({
+      kind: 'invalid_response',
+    });
+  });
+
+  it('tracks the reported rate limit state', async () => {
+    const resetAt = Math.floor(Date.now() / 1000) + 600;
+    const { client } = makeClient([
+      json(
+        {},
+        {
+          headers: {
+            'x-ratelimit-remaining': '4321',
+            'x-ratelimit-limit': '5000',
+            'x-ratelimit-reset': String(resetAt),
+          },
+        },
+      ),
+    ]);
+    await client.request({ path: 'repos/a/b' });
+    expect(client.rateLimit.remaining).toBe(4321);
+    expect(client.rateLimit.limit).toBe(5000);
+    expect(client.rateLimit.resetAt?.getTime()).toBe(resetAt * 1000);
+  });
+});
+
+describe('GitHubClient error mapping', () => {
+  it.each([
+    [404, 'not_found'],
+    [401, 'forbidden'],
+    [451, 'forbidden'],
+    [418, 'unexpected'],
+  ])('maps %i to %s', async (status, kind) => {
+    const { client } = makeClient([json({ message: 'nope' }, { status })]);
+    await expect(client.request({ path: 'repos/a/b' })).rejects.toMatchObject({ kind });
+  });
+
+  it('maps 403 without rate-limit headers to forbidden', async () => {
+    const { client } = makeClient([json({}, { status: 403 })]);
+    await expect(client.request({ path: 'repos/a/b' })).rejects.toMatchObject({
+      kind: 'forbidden',
+    });
+  });
+});
+
+describe('GitHubClient rate limiting', () => {
+  it('maps an exhausted primary limit to RateLimitError with a reset time', async () => {
+    const resetAt = Math.floor(Date.now() / 1000) + 900;
+    const { client } = makeClient([
+      json(
+        {},
+        {
+          status: 403,
+          headers: {
+            'x-ratelimit-remaining': '0',
+            'x-ratelimit-reset': String(resetAt),
+          },
+        },
+      ),
+    ]);
+
+    const error = await client.request({ path: 'repos/a/b' }).catch((e) => e);
+    expect(isRateLimitError(error)).toBe(true);
+    expect((error as RateLimitError).isSecondary).toBe(false);
+    expect((error as RateLimitError).resetAt?.getTime()).toBe(resetAt * 1000);
+  });
+
+  it('maps 429 with retry-after to a secondary limit', async () => {
+    const { client } = makeClient([
+      json({}, { status: 429, headers: { 'retry-after': '60' } }),
+    ]);
+    const error = await client.request({ path: 'repos/a/b' }).catch((e) => e);
+    expect(isRateLimitError(error)).toBe(true);
+    expect((error as RateLimitError).isSecondary).toBe(true);
+    expect((error as RateLimitError).resetAt).toBeInstanceOf(Date);
+  });
+
+  it('does not retry into a rate limit', async () => {
+    const { client, fetchImpl } = makeClient([
+      json({}, { status: 429, headers: { 'retry-after': '60' } }),
+    ]);
+    await client.request({ path: 'repos/a/b' }).catch(() => {});
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('GitHubClient retries', () => {
+  it('retries 5xx and succeeds', async () => {
+    const { client, fetchImpl } = makeClient([
+      json({}, { status: 500 }),
+      json({}, { status: 502 }),
+      json({ id: 1 }),
+    ]);
+    const response = await client.request<{ id: number }>({ path: 'repos/a/b' });
+    expect(response.data).toEqual({ id: 1 });
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
+  });
+
+  it('gives up after the retry limit', async () => {
+    const { client, fetchImpl } = makeClient([json({}, { status: 500 })]);
+    await expect(client.request({ path: 'repos/a/b' })).rejects.toMatchObject({
+      kind: 'unexpected',
+      status: 500,
+    });
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
+  });
+
+  it.each([
+    ['404', 404],
+    ['401', 401],
+    ['422', 422],
+  ])('never retries %s', async (_label, status) => {
+    const { client, fetchImpl } = makeClient([json({}, { status })]);
+    await client.request({ path: 'repos/a/b' }).catch(() => {});
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries network failures then reports them', async () => {
+    const { client, fetchImpl } = makeClient([new TypeError('connection reset')]);
+    await expect(client.request({ path: 'repos/a/b' })).rejects.toMatchObject({
+      kind: 'network',
+    });
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
+  });
+
+  it('reports a timeout distinctly from a network failure', async () => {
+    const timeout = new Error('timed out');
+    timeout.name = 'TimeoutError';
+    const { client } = makeClient([timeout]);
+    await expect(client.request({ path: 'repos/a/b' })).rejects.toMatchObject({
+      kind: 'timeout',
+    });
+  });
+
+  it('does not retry a caller-initiated abort', async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const { client, fetchImpl } = makeClient([new Error('aborted')]);
+
+    await expect(
+      client.request({ path: 'repos/a/b', signal: controller.signal }),
+    ).rejects.toMatchObject({ kind: 'timeout' });
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it('applies bounded jittered backoff rather than a fixed delay', async () => {
+    const delays: number[] = [];
+    const { client } = makeClient([json({}, { status: 500 })], {
+      sleep: async (ms: number) => {
+        delays.push(ms);
+      },
+      maxRetries: 3,
+    });
+
+    await client.request({ path: 'repos/a/b' }).catch(() => {});
+    expect(delays).toHaveLength(3);
+    // Full jitter: each delay lies within [base/2, base] and grows.
+    expect(delays[0]).toBeGreaterThanOrEqual(500);
+    expect(delays[0]).toBeLessThanOrEqual(1000);
+    expect(delays[2]).toBeLessThanOrEqual(8000);
+  });
+});
+
+describe('GitHubClient request budget', () => {
+  it('refuses requests once the budget is spent', async () => {
+    const { client, fetchImpl } = makeClient([json({})], {
+      budget: new RequestBudget(2),
+    });
+
+    await client.request({ path: 'repos/a/b' });
+    await client.request({ path: 'repos/a/c' });
+    await expect(client.request({ path: 'repos/a/d' })).rejects.toMatchObject({
+      kind: 'budget_exhausted',
+    });
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it('counts a request once regardless of how many retries it took', async () => {
+    const { client } = makeClient(
+      [json({}, { status: 500 }), json({}, { status: 500 }), json({ ok: true })],
+      { budget: new RequestBudget(5) },
+    );
+    await client.request({ path: 'repos/a/b' });
+    expect(client.budget.spent).toBe(1);
+  });
+});
+
+describe('GitHubClient pagination', () => {
+  function page(items: unknown[], hasNext: boolean) {
+    return json(items, {
+      headers: hasNext ? { link: '<https://api.github.com/x?page=2>; rel="next"' } : {},
+    });
+  }
+
+  it('follows pages until the last one', async () => {
+    const { client } = makeClient([
+      page([1, 2], true),
+      page([3, 4], true),
+      page([5], false),
+    ]);
+    const result = await client.paginate<number>({
+      path: 'repos/a/b/issues',
+      maxItems: 100,
+    });
+    expect(result.items).toEqual([1, 2, 3, 4, 5]);
+    expect(result.truncated).toBe(false);
+  });
+
+  it('reports truncation when it stops at maxItems', async () => {
+    const { client } = makeClient([page([1, 2, 3], true)]);
+    const result = await client.paginate<number>({
+      path: 'repos/a/b/issues',
+      maxItems: 3,
+    });
+    expect(result.items).toHaveLength(3);
+    expect(result.truncated).toBe(true);
+  });
+
+  it('reports truncation when the budget runs out mid-collection', async () => {
+    const { client } = makeClient([page([1, 2], true)], {
+      budget: new RequestBudget(1),
+    });
+    const result = await client.paginate<number>({
+      path: 'repos/a/b/issues',
+      maxItems: 100,
+    });
+    expect(result.items).toEqual([1, 2]);
+    expect(result.truncated).toBe(true);
+  });
+
+  it('handles an empty first page', async () => {
+    const { client } = makeClient([page([], false)]);
+    const result = await client.paginate<number>({
+      path: 'repos/a/b/issues',
+      maxItems: 50,
+    });
+    expect(result.items).toEqual([]);
+    expect(result.truncated).toBe(false);
+  });
+});
+
+describe('credential safety', () => {
+  let capturedLogs: string[];
+
+  beforeEach(() => {
+    capturedLogs = [];
+    vi.spyOn(console, 'error').mockImplementation((...args) => {
+      capturedLogs.push(args.map(String).join(' '));
+    });
+    vi.spyOn(console, 'warn').mockImplementation((...args) => {
+      capturedLogs.push(args.map(String).join(' '));
+    });
+  });
+
+  it('sends the token as a bearer credential', async () => {
+    const { client, calls } = makeClient([json({})]);
+    await client.request({ path: 'repos/a/b' });
+    expect(new Headers(calls[0]?.init.headers).get('authorization')).toBe(
+      `Bearer ${TOKEN}`,
+    );
+  });
+
+  it('never includes the token in a thrown error', async () => {
+    const { client } = makeClient([json({ message: 'no' }, { status: 500 })]);
+    const error = await client.request({ path: 'repos/a/b' }).catch((e) => e);
+
+    // Check the message, the stack, and a full serialization of the error.
+    const serialized = JSON.stringify(error, Object.getOwnPropertyNames(error as object));
+    expect(error.message).not.toContain(TOKEN);
+    expect(String(error.stack)).not.toContain(TOKEN);
+    expect(serialized).not.toContain(TOKEN);
+    expect(capturedLogs.join('\n')).not.toContain(TOKEN);
+  });
+
+  it('never includes the token in a rate limit error', async () => {
+    const { client } = makeClient([
+      json({}, { status: 429, headers: { 'retry-after': '30' } }),
+    ]);
+    const error = await client.request({ path: 'repos/a/b' }).catch((e) => e);
+    const serialized = JSON.stringify(error, Object.getOwnPropertyNames(error as object));
+    expect(serialized).not.toContain(TOKEN);
+  });
+
+  it('falls back to GITHUB_TOKEN from the environment when none is passed', async () => {
+    vi.stubEnv('GITHUB_TOKEN', 'env-token');
+    const { client, calls } = makeClient([json({})], { token: undefined });
+    await client.request({ path: 'repos/a/b' });
+    expect(new Headers(calls[0]?.init.headers).get('authorization')).toBe(
+      'Bearer env-token',
+    );
+    vi.unstubAllEnvs();
+  });
+
+  it('omits the authorization header entirely when no token is configured', async () => {
+    // Unauthenticated requests are still valid against public data — they just
+    // get a much lower rate limit. Sending `Bearer undefined` would 401.
+    vi.stubEnv('GITHUB_TOKEN', '');
+    const { client, calls } = makeClient([json({})], { token: undefined });
+    await client.request({ path: 'repos/a/b' });
+    expect(new Headers(calls[0]?.init.headers).has('authorization')).toBe(false);
+    vi.unstubAllEnvs();
+  });
+});
+
+describe('RequestBudget', () => {
+  it('rejects a non-positive limit', () => {
+    expect(() => new RequestBudget(0)).toThrow(RangeError);
+    expect(() => new RequestBudget(-1)).toThrow(RangeError);
+    expect(() => new RequestBudget(1.5)).toThrow(RangeError);
+  });
+
+  it('tracks spending and reports exhaustion', () => {
+    const budget = new RequestBudget(2);
+    expect(budget.remaining).toBe(2);
+    expect(budget.tryConsume()).toBe(true);
+    expect(budget.tryConsume()).toBe(true);
+    expect(budget.tryConsume()).toBe(false);
+    expect(budget.exhausted).toBe(true);
+    expect(budget.remaining).toBe(0);
+    expect(budget.spent).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary

A thin, typed wrapper over `fetch` that carries every transport policy in one place: auth, timeouts, retries, rate-limit accounting, ETags, and a hard per-analysis request budget.

Closes #9

## Why

The [README explains](https://github.com/mateoosoriodelhonte/reposignal/blob/main/README.md#why-a-hand-written-github-client-instead-of-octokit) why this is hand-written rather than Octokit. Concretely, three policies were the deciding factor, and all three are visible in the public signatures here:

1. **A hard request budget.** Without one, a repository with 8,000 open issues paginates until the rate limit is gone and every other user is locked out.
2. **Truncation surfaced, not hidden.** `paginate` returns `{ items, truncated }`. Stopping quietly at a page boundary and reporting the result as complete is exactly the dishonesty this project exists to avoid — truncation flows onto the snapshot and lowers the affected category's confidence.
3. **Rate limits fail fast with a reset time**, rather than retrying into the wall. Waiting out a limit inside a request handler converts a fast failure into a slow one.

## Changes

**SSRF boundary, second half.** Paths containing `..`, `//`, or a scheme are refused before any call is made; the origin is re-asserted after URL construction; redirects are surfaced as errors rather than followed. Together with the parser from #8 this closes the boundary at both ends.

**Retry policy.** 5xx and network faults only, capped, with full jitter. Jitter matters more than the base delay: without it, concurrent analyses that hit a 5xx together retry in lockstep and hit GitHub again simultaneously. A caller-initiated abort is not treated as a transient fault.

**Rate limiting.** Distinguishes the primary limit (`remaining: 0`) from the secondary abuse limit (`retry-after`), because they need different messages and only one has a fixed reset time.

**ETags.** Threaded through so an unchanged resource costs no rate limit. `304` returns `null` data, which is how a caller learns its cached copy is still current.

**Errors.** A closed taxonomy keyed by `kind` rather than parsed messages, so the analysis layer maps each to a distinct user-facing explanation instead of a generic failure.

## Bug found while testing

The redirect guard was written as `status >= 300 && status < 400`, which swallowed `304 Not Modified` before the cache path could run — the ETag support would have silently never worked. Redirect statuses are now enumerated explicitly, with a comment saying why the range check is wrong.

## Testing

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test` — 113 passing
- [x] `npm run build`

```
File          | % Stmts | % Branch | % Funcs | % Lines
--------------|---------|----------|---------|--------
All files     |   97.25 |     92.4 |   89.28 |   98.25
 client.ts    |   96.36 |    93.54 |   83.33 |   98.07
```

Covered explicitly: every error class, retry behavior including *not* retrying 4xx, backoff bounds, timeout vs. network distinction, budget exhaustion mid-pagination, truncation reporting, and a credential-safety test asserting the token appears in no thrown error, stack, serialization, or captured log line.

## Risks

`redirect: 'manual'` behaves differently across fetch implementations. Under Node's undici the 3xx response is returned and we reject it, which is what the test asserts. A runtime that returns an opaque response instead would surface as an `invalid_response` rather than a redirect error — still a failure, just a less precise one.

## Checklist

- [x] Scope matches the linked issue
- [x] Tests cover the new behavior, including null and partial-data paths
- [x] No scoring rules changed, so no version bump required
- [x] No secrets, tokens, or personal data added to the repository or logs
- [x] Documentation updated where behavior changed (CHANGELOG)