### PR TITLE
feat: build the repository normalization layer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,18 +83,35 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      # Decided before anything expensive runs. Installing browsers takes
+      # minutes (`--with-deps` shells out to apt), so discovering there is
+      # nothing to test afterwards wastes the entire job.
+      - name: Check for E2E specs
+        id: specs
+        shell: bash
+        run: |
+          if compgen -G "tests/e2e/*.spec.ts" > /dev/null; then
+            echo 'present=true' >> "$GITHUB_OUTPUT"
+          else
+            echo 'present=false' >> "$GITHUB_OUTPUT"
+            echo 'No E2E specs yet — skipping the rest of this job.'
+          fi
+
       - uses: actions/setup-node@v7
+        if: steps.specs.outputs.present == 'true'
         with:
           node-version: 22
           cache: npm
 
       - name: Install dependencies
+        if: steps.specs.outputs.present == 'true'
         run: npm ci
 
       # The Prisma schema lands with the persistence work (#20). Until then
       # there is nothing to generate, and CI should reflect that honestly
       # rather than fail on a file the project has not reached yet.
       - name: Generate Prisma client
+        if: steps.specs.outputs.present == 'true'
         run: |
           if [ -f prisma/schema.prisma ]; then
             npx prisma generate
@@ -103,19 +120,15 @@ jobs:
           fi
 
       - name: Install Playwright browsers
+        if: steps.specs.outputs.present == 'true'
         run: npx playwright install --with-deps chromium
 
       - name: Run Playwright tests
-        run: |
-          if compgen -G "tests/e2e/*.spec.ts" > /dev/null; then
-            npm run test:e2e
-          else
-            echo "No E2E specs yet — skipping."
-          fi
-        shell: bash
+        if: steps.specs.outputs.present == 'true'
+        run: npm run test:e2e
 
       - name: Upload Playwright report
-        if: ${{ !cancelled() }}
+        if: ${{ steps.specs.outputs.present == 'true' && !cancelled() }}
         uses: actions/upload-artifact@v7
         with:
           name: playwright-report

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ analysis records the `scoringVersion` it was produced under.
 
 ### Added
 
+- Repository normalization layer: Zod-parsed GitHub payloads mapped into a
+  `RepositorySnapshot`, with pull requests excluded from all issue data,
+  unobservable values preserved as `null`, sample truncation recorded, and
+  per-endpoint failures collected rather than aborting the analysis
 - GitHub API client: a typed `fetch` wrapper with bearer auth, per-request
   timeouts, bounded jittered retry on 5xx and network errors only, rate-limit
   accounting with reset times, ETag conditional requests, a hard per-analysis

--- a/src/lib/github/collector.ts
+++ b/src/lib/github/collector.ts
@@ -1,0 +1,335 @@
+import {
+  normalizeActivity,
+  normalizeCi,
+  normalizeCommunity,
+  normalizeFiles,
+  normalizeIdentity,
+  normalizeIssues,
+  normalizePullRequests,
+} from '@/lib/normalize/snapshot';
+import type { RepositoryReference } from '@/lib/validation/repository-reference';
+import type { CollectionReport, RepositorySnapshot } from '@/types/snapshot';
+
+import type { GitHubClient } from './client';
+import { GitHubError } from './errors';
+import {
+  commitActivitySchema,
+  combinedStatusSchema,
+  contentListSchema,
+  issueSchema,
+  pullRequestSchema,
+  releaseSchema,
+  repositorySchema,
+  workflowListSchema,
+  workflowRunListSchema,
+} from './schemas';
+
+/**
+ * Assembles a `RepositorySnapshot` from GitHub.
+ *
+ * The organising principle: **only the repository itself is required.** Every
+ * other endpoint is allowed to fail, and a failure records an entry in the
+ * `CollectionReport` and leaves its field `null` rather than aborting. A
+ * repository whose workflow runs are unreadable still deserves a documentation
+ * score.
+ *
+ * The exception is a rate limit, which is rethrown. Continuing after one would
+ * produce a snapshot that is mostly holes and score it as though the holes
+ * were observations.
+ */
+
+/** Caps on how much of each collection is sampled, to bound the request cost. */
+const SAMPLE_LIMITS = {
+  issues: 300,
+  pullRequests: 200,
+  releases: 100,
+  workflowRuns: 100,
+  workflowFiles: 5,
+} as const;
+
+class Collector {
+  readonly failures: CollectionReport['failures'] = [];
+
+  constructor(
+    private readonly client: GitHubClient,
+    private readonly ref: RepositoryReference,
+  ) {}
+
+  get base(): string {
+    return `repos/${this.ref.owner}/${this.ref.name}`;
+  }
+
+  /**
+   * Runs a collection step, converting failure into a recorded absence.
+   *
+   * Rate limits are rethrown: they affect every remaining step, so continuing
+   * would silently degrade the whole analysis rather than one field of it.
+   */
+  async attempt<T>(resource: string, run: () => Promise<T>): Promise<T | null> {
+    try {
+      return await run();
+    } catch (error) {
+      if (error instanceof GitHubError && error.kind === 'rate_limited') {
+        throw error;
+      }
+
+      this.failures.push({
+        resource,
+        reason: error instanceof GitHubError ? error.kind : 'unexpected',
+      });
+      return null;
+    }
+  }
+}
+
+/** Lists a directory, treating "no such directory" as an empty listing. */
+async function listDirectory(
+  client: GitHubClient,
+  path: string,
+): Promise<
+  Array<{
+    name: string;
+    path: string;
+    type: string;
+    size: number;
+    html_url: string | null;
+  }>
+> {
+  const response = await client.request<unknown>({ path });
+  const parsed = contentListSchema.safeParse(response.data);
+  return parsed.success ? parsed.data : [];
+}
+
+/**
+ * Counts a collection without enumerating it.
+ *
+ * Requesting one item per page makes the `last` link's page number equal the
+ * total count. That turns an unbounded enumeration — 4,000 contributors is
+ * 40 requests at 100 per page — into exactly one.
+ */
+async function countViaPagination(
+  client: GitHubClient,
+  path: string,
+): Promise<number | null> {
+  const response = await client.request<unknown[]>({
+    path,
+    searchParams: { per_page: 1 },
+  });
+
+  const last = response.links['last'];
+  if (last !== undefined) {
+    const page = new URL(last).searchParams.get('page');
+    if (page !== null) {
+      const parsed = Number.parseInt(page, 10);
+      if (Number.isFinite(parsed)) return parsed;
+    }
+  }
+
+  // No `last` link means zero or one page, so the item count is what came back.
+  return Array.isArray(response.data) ? response.data.length : null;
+}
+
+export async function collectSnapshot(
+  client: GitHubClient,
+  ref: RepositoryReference,
+  now: Date,
+): Promise<RepositorySnapshot> {
+  const collector = new Collector(client, ref);
+  const base = collector.base;
+
+  // The repository itself is the one required call. Its failure — a 404, a
+  // private repository — is the caller's to handle.
+  const repositoryResponse = await client.request<unknown>({ path: base });
+  const repository = repositorySchema.parse(repositoryResponse.data);
+  const identity = normalizeIdentity(repository);
+
+  const rootEntries =
+    (await collector.attempt('contents', () =>
+      listDirectory(client, `${base}/contents`),
+    )) ?? [];
+
+  const githubDirEntries =
+    (await collector.attempt('contents/.github', () =>
+      listDirectory(client, `${base}/contents/.github`),
+    )) ?? [];
+
+  const hasIssueTemplates = githubDirEntries.some(
+    (entry) => entry.type === 'dir' && entry.name.toLowerCase() === 'issue_template',
+  );
+  const hasPullRequestTemplate = githubDirEntries.some(
+    (entry) =>
+      entry.type === 'file' &&
+      entry.name.toLowerCase().startsWith('pull_request_template'),
+  );
+
+  // Workflow file contents are read as text to detect security scanning steps.
+  // Nothing is executed or evaluated — see SECURITY.md.
+  const workflowFiles =
+    (await collector.attempt('contents/.github/workflows', () =>
+      listDirectory(client, `${base}/contents/.github/workflows`),
+    )) ?? [];
+
+  const workflowContents: string[] = [];
+  for (const entry of workflowFiles.slice(0, SAMPLE_LIMITS.workflowFiles)) {
+    const content = await collector.attempt(`workflow:${entry.name}`, async () => {
+      const response = await client.request<unknown>({
+        path: `${base}/contents/${entry.path}`,
+        accept: 'application/vnd.github.raw+json',
+      });
+      return typeof response.data === 'string'
+        ? response.data
+        : JSON.stringify(response.data);
+    });
+    if (content !== null) workflowContents.push(content);
+  }
+
+  const issuesResult = await collector.attempt('issues', () =>
+    client.paginate<unknown>({
+      path: `${base}/issues`,
+      searchParams: { state: 'all', sort: 'created', direction: 'desc' },
+      maxItems: SAMPLE_LIMITS.issues,
+    }),
+  );
+
+  const pullsResult = await collector.attempt('pulls', () =>
+    client.paginate<unknown>({
+      path: `${base}/pulls`,
+      searchParams: { state: 'all', sort: 'created', direction: 'desc' },
+      maxItems: SAMPLE_LIMITS.pullRequests,
+    }),
+  );
+
+  const releasesResult = await collector.attempt('releases', () =>
+    client.paginate<unknown>({
+      path: `${base}/releases`,
+      maxItems: SAMPLE_LIMITS.releases,
+    }),
+  );
+
+  const tagCount = await collector.attempt('tags', () =>
+    countViaPagination(client, `${base}/tags`),
+  );
+
+  const contributorCount = await collector.attempt('contributors', () =>
+    countViaPagination(client, `${base}/contributors`),
+  );
+
+  const weeklyCommits = await collector.attempt('stats/commit_activity', async () => {
+    const response = await client.request<unknown>({
+      path: `${base}/stats/commit_activity`,
+    });
+    // GitHub answers 202 with no body while it computes statistics. That is
+    // "not yet known", which must stay null rather than becoming zero commits.
+    if (response.status === 202 || response.data === null) return null;
+
+    const parsed = commitActivitySchema.safeParse(response.data);
+    return parsed.success ? parsed.data.map((week) => week.total) : null;
+  });
+
+  const workflows = await collector.attempt('actions/workflows', async () => {
+    const response = await client.request<unknown>({ path: `${base}/actions/workflows` });
+    return workflowListSchema.safeParse(response.data);
+  });
+
+  const runs = await collector.attempt('actions/runs', async () => {
+    const response = await client.request<unknown>({
+      path: `${base}/actions/runs`,
+      searchParams: {
+        branch: identity.defaultBranch,
+        per_page: SAMPLE_LIMITS.workflowRuns,
+      },
+    });
+    return workflowRunListSchema.safeParse(response.data);
+  });
+
+  const commitStatus = await collector.attempt('commit status', async () => {
+    const response = await client.request<unknown>({
+      path: `${base}/commits/${identity.defaultBranch}/status`,
+    });
+    const parsed = combinedStatusSchema.safeParse(response.data);
+    if (!parsed.success) return null;
+    // `pending` with no checks at all means there is no CI on this commit,
+    // which is different from a check that is still running.
+    return parsed.data.total_count === 0 ? 'none' : parsed.data.state;
+  });
+
+  // Branch protection requires elevated permissions on most repositories.
+  // A 403 here is expected and must stay `null` — "unable to verify" — rather
+  // than being recorded as "not protected".
+  const branchProtected = await collector.attempt('branch protection', async () => {
+    await client.request<unknown>({
+      path: `${base}/branches/${identity.defaultBranch}/protection`,
+    });
+    return true;
+  });
+
+  const issueRaws = (issuesResult?.items ?? [])
+    .map((item) => issueSchema.safeParse(item))
+    .flatMap((parsed) => (parsed.success ? [parsed.data] : []));
+
+  const pullRaws = (pullsResult?.items ?? [])
+    .map((item) => pullRequestSchema.safeParse(item))
+    .flatMap((parsed) => (parsed.success ? [parsed.data] : []));
+
+  const releaseRaws = (releasesResult?.items ?? [])
+    .map((item) => releaseSchema.safeParse(item))
+    .flatMap((parsed) => (parsed.success ? [parsed.data] : []));
+
+  const workflowList = workflows?.success ? workflows.data : null;
+  const runList = runs?.success ? runs.data : null;
+
+  return {
+    capturedAt: now.toISOString(),
+    identity,
+    activity: normalizeActivity({
+      repository,
+      releases: releaseRaws,
+      weeklyCommits: weeklyCommits ?? null,
+      contributorCount: contributorCount ?? null,
+      tagCount: tagCount ?? null,
+    }),
+    issues: normalizeIssues({
+      raws: issueRaws,
+      sample: {
+        examined: issueRaws.length,
+        truncated: issuesResult?.truncated ?? false,
+      },
+      hasIssuesEnabled: repository.has_issues,
+      now,
+    }),
+    pullRequests: normalizePullRequests({
+      raws: pullRaws,
+      sample: {
+        examined: pullRaws.length,
+        truncated: pullsResult?.truncated ?? false,
+      },
+      now,
+    }),
+    ci: normalizeCi({
+      workflowCount: workflowList?.total_count ?? null,
+      workflowFileNames: workflowList?.workflows.map((w) => w.path) ?? [],
+      runConclusions: runList?.workflow_runs.map((run) => run.conclusion) ?? [],
+      latestCommitStatus: commitStatus ?? null,
+      sample: {
+        examined: runList?.workflow_runs.length ?? 0,
+        truncated: (runList?.total_count ?? 0) > SAMPLE_LIMITS.workflowRuns,
+      },
+    }),
+    files: normalizeFiles({
+      rootEntries,
+      githubDirEntries,
+      hasIssueTemplates,
+      hasPullRequestTemplate,
+      workflowContents,
+    }),
+    community: normalizeCommunity({
+      repository,
+      defaultBranchProtected: branchProtected,
+    }),
+    collection: {
+      requestsMade: client.budget.spent,
+      failures: collector.failures,
+      rateLimitRemaining: client.rateLimit.remaining,
+    },
+  };
+}

--- a/src/lib/github/schemas.ts
+++ b/src/lib/github/schemas.ts
@@ -1,0 +1,148 @@
+import { z } from 'zod';
+
+/**
+ * Zod schemas for the GitHub payloads RepoSignal reads.
+ *
+ * These are the last place GitHub's vocabulary is allowed to appear. They are
+ * deliberately loose about fields RepoSignal does not use (`.loose()` keeps
+ * unknown keys rather than rejecting them) and strict about the ones it does,
+ * because a silently-missing field would become a silently-wrong score.
+ *
+ * Every optional field maps to `null` downstream, never to a default.
+ */
+
+export const repositorySchema = z
+  .object({
+    id: z.number(),
+    name: z.string(),
+    full_name: z.string(),
+    owner: z.object({ login: z.string() }),
+    html_url: z.string(),
+    description: z.string().nullable().default(null),
+    created_at: z.string(),
+    pushed_at: z.string().nullable().default(null),
+    default_branch: z.string(),
+    archived: z.boolean().default(false),
+    fork: z.boolean().default(false),
+    stargazers_count: z.number().default(0),
+    forks_count: z.number().default(0),
+    open_issues_count: z.number().default(0),
+    has_issues: z.boolean().default(true),
+    homepage: z.string().nullable().default(null),
+    topics: z.array(z.string()).default([]),
+    license: z.object({ spdx_id: z.string().nullable() }).nullable().default(null),
+  })
+  .loose();
+
+export type RawRepository = z.infer<typeof repositorySchema>;
+
+/**
+ * GitHub's issues endpoints return pull requests as issues. The presence of
+ * `pull_request` is the only reliable discriminator, which is why it is
+ * modelled here rather than filtered by guesswork downstream.
+ */
+export const issueSchema = z
+  .object({
+    number: z.number(),
+    state: z.string(),
+    created_at: z.string(),
+    updated_at: z.string(),
+    closed_at: z.string().nullable().default(null),
+    html_url: z.string(),
+    pull_request: z.unknown().optional(),
+  })
+  .loose();
+
+export type RawIssue = z.infer<typeof issueSchema>;
+
+export const pullRequestSchema = z
+  .object({
+    number: z.number(),
+    state: z.string(),
+    created_at: z.string(),
+    updated_at: z.string(),
+    closed_at: z.string().nullable().default(null),
+    merged_at: z.string().nullable().default(null),
+    draft: z.boolean().default(false),
+    html_url: z.string(),
+  })
+  .loose();
+
+export type RawPullRequest = z.infer<typeof pullRequestSchema>;
+
+export const releaseSchema = z
+  .object({
+    tag_name: z.string(),
+    published_at: z.string().nullable().default(null),
+    prerelease: z.boolean().default(false),
+    draft: z.boolean().default(false),
+    html_url: z.string(),
+  })
+  .loose();
+
+export type RawRelease = z.infer<typeof releaseSchema>;
+
+export const workflowSchema = z
+  .object({
+    id: z.number(),
+    name: z.string(),
+    path: z.string(),
+    state: z.string(),
+  })
+  .loose();
+
+export const workflowListSchema = z
+  .object({
+    total_count: z.number().default(0),
+    workflows: z.array(workflowSchema).default([]),
+  })
+  .loose();
+
+export const workflowRunSchema = z
+  .object({
+    id: z.number(),
+    conclusion: z.string().nullable().default(null),
+    status: z.string().nullable().default(null),
+    created_at: z.string(),
+    head_branch: z.string().nullable().default(null),
+    html_url: z.string(),
+  })
+  .loose();
+
+export const workflowRunListSchema = z
+  .object({
+    total_count: z.number().default(0),
+    workflow_runs: z.array(workflowRunSchema).default([]),
+  })
+  .loose();
+
+export const combinedStatusSchema = z
+  .object({
+    state: z.string(),
+    total_count: z.number().default(0),
+  })
+  .loose();
+
+/**
+ * One entry from a directory listing. RepoSignal reads listings rather than
+ * file contents wherever presence alone is the signal, because a listing costs
+ * one request for an entire directory.
+ */
+export const contentEntrySchema = z
+  .object({
+    name: z.string(),
+    path: z.string(),
+    type: z.string(),
+    size: z.number().default(0),
+    html_url: z.string().nullable().default(null),
+  })
+  .loose();
+
+export const contentListSchema = z.array(contentEntrySchema);
+
+export type RawContentEntry = z.infer<typeof contentEntrySchema>;
+
+/** Weekly commit activity. GitHub returns `202` with no body while computing. */
+export const commitActivitySchema = z.array(
+  z.object({ total: z.number(), week: z.number() }).loose(),
+);

--- a/src/lib/normalize/dates.ts
+++ b/src/lib/normalize/dates.ts
@@ -1,0 +1,56 @@
+/**
+ * Date helpers shared across normalization and scoring.
+ *
+ * All of them are total: an unparseable or absent input yields `null` rather
+ * than `NaN` or `0`. A `NaN` age silently compared against a threshold is
+ * exactly how "we don't know" becomes "it's bad".
+ */
+
+const MS_PER_DAY = 86_400_000;
+
+/** Parses an ISO timestamp, returning `null` for absent or invalid input. */
+export function parseDate(value: string | null | undefined): Date | null {
+  if (value === null || value === undefined || value === '') return null;
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+/**
+ * Whole days between two instants, rounded down and never negative.
+ *
+ * A timestamp slightly in the future — clock skew, or a scheduled release —
+ * yields 0 rather than a negative age that would compare strangely against
+ * every threshold.
+ */
+export function daysBetween(from: Date, to: Date): number {
+  return Math.max(0, Math.floor((to.getTime() - from.getTime()) / MS_PER_DAY));
+}
+
+/** Age in days of an ISO timestamp, or `null` if it is absent or invalid. */
+export function ageInDays(value: string | null | undefined, now: Date): number | null {
+  const date = parseDate(value);
+  return date === null ? null : daysBetween(date, now);
+}
+
+/** Median of a numeric sample, or `null` when empty. */
+export function median(values: number[]): number | null {
+  if (values.length === 0) return null;
+
+  const sorted = [...values].sort((a, b) => a - b);
+  const middle = Math.floor(sorted.length / 2);
+
+  if (sorted.length % 2 === 1) {
+    return sorted[middle] ?? null;
+  }
+
+  const lower = sorted[middle - 1];
+  const upper = sorted[middle];
+  if (lower === undefined || upper === undefined) return null;
+  return (lower + upper) / 2;
+}
+
+/** Proportion of a sample at or above a threshold, or `null` when empty. */
+export function proportionAtLeast(values: number[], threshold: number): number | null {
+  if (values.length === 0) return null;
+  return values.filter((value) => value >= threshold).length / values.length;
+}

--- a/src/lib/normalize/snapshot.ts
+++ b/src/lib/normalize/snapshot.ts
@@ -1,0 +1,425 @@
+import type {
+  RawContentEntry,
+  RawIssue,
+  RawPullRequest,
+  RawRelease,
+  RawRepository,
+} from '@/lib/github/schemas';
+import type { RepositoryIdentity } from '@/types/analysis';
+import type {
+  ActivitySnapshot,
+  CiSnapshot,
+  CommunitySnapshot,
+  FilePresence,
+  FileSnapshot,
+  IssueSnapshot,
+  PullRequestSnapshot,
+  ReleaseRecord,
+  SampleReport,
+  WorkflowConclusion,
+} from '@/types/snapshot';
+
+import { ageInDays } from './dates';
+
+/**
+ * Normalization: GitHub payloads in, domain types out.
+ *
+ * This is the last layer that knows GitHub's field names. Everything below it
+ * — metrics, findings, scoring, UI — works with `RepositorySnapshot` only, so
+ * a GitHub API change is contained to this directory and its tests.
+ *
+ * Every function here is total. Unparseable or absent input becomes `null`,
+ * never a default value, because a default is indistinguishable from an
+ * observation once it reaches scoring.
+ */
+
+const ABSENT: FilePresence = {
+  present: false,
+  path: null,
+  sizeBytes: null,
+  htmlUrl: null,
+};
+
+/** Lockfiles RepoSignal recognizes, across the ecosystems it is likely to meet. */
+const LOCKFILES = new Set([
+  'package-lock.json',
+  'yarn.lock',
+  'pnpm-lock.yaml',
+  'bun.lockb',
+  'bun.lock',
+  'requirements.txt',
+  'poetry.lock',
+  'pipfile.lock',
+  'uv.lock',
+  'cargo.lock',
+  'go.sum',
+  'gemfile.lock',
+  'composer.lock',
+  'packages.lock.json',
+  'mix.lock',
+  'pubspec.lock',
+  'gradle.lockfile',
+]);
+
+/**
+ * Workflow steps that indicate security scanning.
+ *
+ * Matched as plain text against workflow file contents. Nothing is executed or
+ * evaluated — RepoSignal reads workflow YAML as a string and looks for these
+ * substrings, which is the full extent of its "security scanning detection".
+ */
+const SECURITY_SCANNERS = [
+  'github/codeql-action',
+  'aquasecurity/trivy-action',
+  'snyk/actions',
+  'returntocorp/semgrep',
+  'semgrep/semgrep',
+  'npm audit',
+  'pnpm audit',
+  'yarn audit',
+  'gitleaks',
+  'trufflesecurity/trufflehog',
+  'dependency-review-action',
+  'ossf/scorecard-action',
+  'anchore/scan-action',
+  'pip-audit',
+  'cargo audit',
+  'bundler-audit',
+];
+
+export function normalizeIdentity(raw: RawRepository): RepositoryIdentity {
+  return {
+    githubId: raw.id,
+    owner: raw.owner.login,
+    name: raw.name,
+    fullName: raw.full_name,
+    htmlUrl: raw.html_url,
+    description: raw.description,
+    isArchived: raw.archived,
+    isFork: raw.fork,
+    defaultBranch: raw.default_branch,
+  };
+}
+
+export function normalizeReleases(raws: RawRelease[]): ReleaseRecord[] {
+  return (
+    raws
+      // Drafts are unpublished and invisible to users, so they are not releases
+      // for cadence purposes.
+      .filter((raw) => !raw.draft)
+      .map((raw) => ({
+        tagName: raw.tag_name,
+        publishedAt: raw.published_at,
+        isPrerelease: raw.prerelease,
+        htmlUrl: raw.html_url,
+      }))
+  );
+}
+
+export function normalizeActivity(input: {
+  repository: RawRepository;
+  releases: RawRelease[];
+  weeklyCommits: number[] | null;
+  contributorCount: number | null;
+  tagCount: number | null;
+}): ActivitySnapshot {
+  return {
+    createdAt: input.repository.created_at,
+    pushedAt: input.repository.pushed_at,
+    weeklyCommits: input.weeklyCommits,
+    contributorCount: input.contributorCount,
+    releases: normalizeReleases(input.releases),
+    tagCount: input.tagCount,
+    stars: input.repository.stargazers_count,
+    forks: input.repository.forks_count,
+    isArchived: input.repository.archived,
+  };
+}
+
+/**
+ * Removes pull requests from an issue payload.
+ *
+ * GitHub's `/issues` endpoints return pull requests alongside issues, and the
+ * only reliable discriminator is the presence of a `pull_request` key. Failing
+ * to filter here inflates every issue metric on any repository that takes
+ * contributions — which is most of them.
+ */
+export function excludePullRequests(raws: RawIssue[]): RawIssue[] {
+  return raws.filter(
+    (raw) => raw.pull_request === undefined || raw.pull_request === null,
+  );
+}
+
+export function normalizeIssues(input: {
+  raws: RawIssue[];
+  sample: SampleReport;
+  hasIssuesEnabled: boolean;
+  now: Date;
+}): IssueSnapshot | null {
+  // Issues disabled is "not applicable", not "zero issues". Returning null
+  // here is what stops the category scoring as though the backlog were empty.
+  if (!input.hasIssuesEnabled) return null;
+
+  const issues = excludePullRequests(input.raws);
+  const open = issues.filter((issue) => issue.state === 'open');
+
+  const openAgeDays: number[] = [];
+  const openInactiveDays: number[] = [];
+  for (const issue of open) {
+    const age = ageInDays(issue.created_at, input.now);
+    if (age !== null) openAgeDays.push(age);
+
+    const inactive = ageInDays(issue.updated_at, input.now);
+    if (inactive !== null) openInactiveDays.push(inactive);
+  }
+
+  const createdLast90Days = issues.filter((issue) => {
+    const age = ageInDays(issue.created_at, input.now);
+    return age !== null && age <= 90;
+  }).length;
+
+  const closedLast90Days = issues.filter((issue) => {
+    const closed = ageInDays(issue.closed_at, input.now);
+    return closed !== null && closed <= 90;
+  }).length;
+
+  return {
+    openCount: open.length,
+    openAgeDays: openAgeDays.sort((a, b) => a - b),
+    openInactiveDays: openInactiveDays.sort((a, b) => a - b),
+    createdLast90Days,
+    closedLast90Days,
+    sample: input.sample,
+  };
+}
+
+export function normalizePullRequests(input: {
+  raws: RawPullRequest[];
+  sample: SampleReport;
+  now: Date;
+}): PullRequestSnapshot | null {
+  // No pull requests ever means there is nothing to assess, which is distinct
+  // from a repository that merges nothing.
+  if (input.raws.length === 0) return null;
+
+  const open = input.raws.filter((pr) => pr.state === 'open');
+
+  const openAgeDays: number[] = [];
+  for (const pr of open) {
+    const age = ageInDays(pr.created_at, input.now);
+    if (age !== null) openAgeDays.push(age);
+  }
+
+  const mergedDurationDays: number[] = [];
+  let recentlyMergedCount = 0;
+  let recentlyClosedUnmergedCount = 0;
+
+  for (const pr of input.raws) {
+    const mergedAgo = ageInDays(pr.merged_at, input.now);
+
+    if (mergedAgo !== null) {
+      const opened = ageInDays(pr.created_at, input.now);
+      if (opened !== null) {
+        mergedDurationDays.push(Math.max(0, opened - mergedAgo));
+      }
+      if (mergedAgo <= 90) recentlyMergedCount += 1;
+      continue;
+    }
+
+    const closedAgo = ageInDays(pr.closed_at, input.now);
+    if (closedAgo !== null && closedAgo <= 90) {
+      recentlyClosedUnmergedCount += 1;
+    }
+  }
+
+  return {
+    openCount: open.length,
+    openAgeDays: openAgeDays.sort((a, b) => a - b),
+    mergedDurationDays: mergedDurationDays.sort((a, b) => a - b),
+    recentlyMergedCount,
+    recentlyClosedUnmergedCount,
+    sample: input.sample,
+  };
+}
+
+const KNOWN_CONCLUSIONS = new Set<WorkflowConclusion>([
+  'success',
+  'failure',
+  'cancelled',
+  'skipped',
+  'timed_out',
+  'action_required',
+  'neutral',
+  'stale',
+  'startup_failure',
+]);
+
+export function normalizeConclusion(raw: string | null): WorkflowConclusion {
+  if (raw !== null && KNOWN_CONCLUSIONS.has(raw as WorkflowConclusion)) {
+    return raw as WorkflowConclusion;
+  }
+  return 'unknown';
+}
+
+export function normalizeCi(input: {
+  workflowCount: number | null;
+  workflowFileNames: string[];
+  runConclusions: Array<string | null>;
+  latestCommitStatus: string | null;
+  sample: SampleReport;
+}): CiSnapshot {
+  let latest: CiSnapshot['latestCommitStatus'] = null;
+  if (input.latestCommitStatus !== null) {
+    switch (input.latestCommitStatus) {
+      case 'success':
+      case 'failure':
+      case 'pending':
+        latest = input.latestCommitStatus;
+        break;
+      default:
+        // GitHub reports `state: "pending"` with `total_count: 0` for a commit
+        // with no checks at all. Anything unrecognized is treated as "none"
+        // rather than invented as a status.
+        latest = 'none';
+    }
+  }
+
+  return {
+    workflowCount: input.workflowCount,
+    workflowFileNames: input.workflowFileNames,
+    recentRunConclusions: input.runConclusions.map(normalizeConclusion),
+    latestCommitStatus: latest,
+    sample: input.sample,
+  };
+}
+
+/** Finds a root-level file by any of several accepted names, case-insensitively. */
+export function findFile(entries: RawContentEntry[], candidates: string[]): FilePresence {
+  const wanted = candidates.map((name) => name.toLowerCase());
+
+  for (const entry of entries) {
+    if (entry.type !== 'file') continue;
+    const name = entry.name.toLowerCase();
+
+    // Matches `README`, `README.md`, `README.rst` — the stem is what matters.
+    const matches = wanted.some(
+      (candidate) => name === candidate || name.startsWith(`${candidate}.`),
+    );
+
+    if (matches) {
+      return {
+        present: true,
+        path: entry.path,
+        sizeBytes: entry.size,
+        htmlUrl: entry.html_url,
+      };
+    }
+  }
+
+  return ABSENT;
+}
+
+function findDirectory(entries: RawContentEntry[], names: string[]): FilePresence {
+  const wanted = names.map((name) => name.toLowerCase());
+
+  for (const entry of entries) {
+    if (entry.type !== 'dir') continue;
+    if (wanted.includes(entry.name.toLowerCase())) {
+      return {
+        present: true,
+        path: entry.path,
+        sizeBytes: null,
+        htmlUrl: entry.html_url,
+      };
+    }
+  }
+
+  return ABSENT;
+}
+
+export function detectLockfiles(entries: RawContentEntry[]): string[] {
+  return entries
+    .filter((entry) => entry.type === 'file' && LOCKFILES.has(entry.name.toLowerCase()))
+    .map((entry) => entry.name);
+}
+
+export function detectSecurityScanners(workflowContents: string[]): string[] {
+  const found = new Set<string>();
+
+  for (const content of workflowContents) {
+    const lowered = content.toLowerCase();
+    for (const scanner of SECURITY_SCANNERS) {
+      if (lowered.includes(scanner)) found.add(scanner);
+    }
+  }
+
+  return [...found].sort();
+}
+
+export function normalizeFiles(input: {
+  rootEntries: RawContentEntry[];
+  githubDirEntries: RawContentEntry[];
+  hasIssueTemplates: boolean;
+  hasPullRequestTemplate: boolean;
+  workflowContents: string[];
+}): FileSnapshot {
+  const root = input.rootEntries;
+  const dotGithub = input.githubDirEntries;
+
+  /** Several health files may live at the root or inside `.github/`. */
+  const eitherLocation = (candidates: string[]): FilePresence => {
+    const atRoot = findFile(root, candidates);
+    return atRoot.present ? atRoot : findFile(dotGithub, candidates);
+  };
+
+  const dependencyAutomation = (): FilePresence => {
+    const renovate = findFile(root, ['renovate', '.renovaterc']);
+    if (renovate.present) return renovate;
+
+    const renovateInGithub = findFile(dotGithub, ['renovate']);
+    if (renovateInGithub.present) return renovateInGithub;
+
+    return findFile(dotGithub, ['dependabot']);
+  };
+
+  return {
+    readme: eitherLocation(['readme']),
+    contributing: eitherLocation(['contributing']),
+    license: eitherLocation(['license', 'licence', 'copying']),
+    security: eitherLocation(['security']),
+    codeOfConduct: eitherLocation(['code_of_conduct', 'code-of-conduct']),
+    changelog: eitherLocation(['changelog', 'changes', 'history']),
+    codeowners: eitherLocation(['codeowners']),
+    gitignore: findFile(root, ['.gitignore']),
+    issueTemplates: input.hasIssueTemplates
+      ? { present: true, path: '.github/ISSUE_TEMPLATE', sizeBytes: null, htmlUrl: null }
+      : ABSENT,
+    pullRequestTemplate: input.hasPullRequestTemplate
+      ? {
+          present: true,
+          path: '.github/pull_request_template.md',
+          sizeBytes: null,
+          htmlUrl: null,
+        }
+      : ABSENT,
+    docsDirectory: findDirectory(root, ['docs', 'doc', 'documentation', 'website']),
+    lockfiles: detectLockfiles(root),
+    dependencyAutomation: dependencyAutomation(),
+    securityScanningWorkflows: detectSecurityScanners(input.workflowContents),
+  };
+}
+
+export function normalizeCommunity(input: {
+  repository: RawRepository;
+  defaultBranchProtected: boolean | null;
+}): CommunitySnapshot {
+  return {
+    hasDescription:
+      input.repository.description !== null && input.repository.description.trim() !== '',
+    hasHomepage:
+      input.repository.homepage !== null && input.repository.homepage.trim() !== '',
+    topicCount: input.repository.topics.length,
+    hasIssuesEnabled: input.repository.has_issues,
+    defaultBranchProtected: input.defaultBranchProtected,
+  };
+}

--- a/tests/unit/github/collector.test.ts
+++ b/tests/unit/github/collector.test.ts
@@ -1,0 +1,307 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { GitHubClient } from '@/lib/github/client';
+import { collectSnapshot } from '@/lib/github/collector';
+import { RequestBudget } from '@/lib/github/request-budget';
+
+const NOW = new Date('2026-06-01T00:00:00Z');
+const REF = { owner: 'facebook', name: 'react' };
+
+const REPOSITORY = {
+  id: 10270250,
+  name: 'react',
+  full_name: 'facebook/react',
+  owner: { login: 'facebook' },
+  html_url: 'https://github.com/facebook/react',
+  description: 'A JavaScript library',
+  created_at: '2013-05-24T16:15:54Z',
+  pushed_at: '2026-05-31T00:00:00Z',
+  default_branch: 'main',
+  archived: false,
+  fork: false,
+  stargazers_count: 220000,
+  forks_count: 45000,
+  open_issues_count: 900,
+  has_issues: true,
+  homepage: 'https://react.dev',
+  topics: ['javascript'],
+  license: { spdx_id: 'MIT' },
+};
+
+/** Base path for the fixture repository, spelled once. */
+const REPO = 'repos/facebook/react';
+
+/**
+ * Routes requests by exact pathname so a test can describe only the endpoints
+ * it cares about. Anything unrouted returns 404, which exercises the
+ * collector's "record the absence and carry on" behavior by default.
+ *
+ * Matching is exact rather than substring because `repos/facebook/react` is a
+ * prefix of every other endpoint, so a substring router would send the whole
+ * collection to the repository handler.
+ */
+function makeClient(routes: Record<string, () => Response>) {
+  const requested: string[] = [];
+
+  const fetchImpl = vi.fn(async (url: string | URL | Request) => {
+    const href = String(url);
+    requested.push(href);
+
+    const pathname = new URL(href).pathname.replace(/^\//, '');
+    const respond = routes[pathname];
+    if (respond) return respond();
+
+    return new Response(JSON.stringify({ message: 'Not Found' }), {
+      status: 404,
+      headers: { 'content-type': 'application/json' },
+    });
+  }) as unknown as typeof fetch;
+
+  const client = new GitHubClient({
+    token: 'test-token',
+    fetchImpl,
+    sleep: async () => {},
+    random: () => 0.5,
+    budget: new RequestBudget(100),
+  });
+
+  return { client, requested };
+}
+
+function ok(body: unknown, headers: Record<string, string> = {}) {
+  return () =>
+    new Response(JSON.stringify(body), {
+      status: 200,
+      headers: { 'content-type': 'application/json', ...headers },
+    });
+}
+
+function status(code: number) {
+  return () =>
+    new Response(JSON.stringify({ message: 'nope' }), {
+      status: code,
+      headers: { 'content-type': 'application/json' },
+    });
+}
+
+/** Routes just enough for the repository call to succeed. */
+const MINIMAL = { [REPO]: ok(REPOSITORY) };
+
+describe('collectSnapshot', () => {
+  it('produces a snapshot when only the repository endpoint succeeds', async () => {
+    // Every other endpoint 404s. A repository whose workflow runs are
+    // unreadable still deserves a documentation score, so partial collection
+    // must produce a usable snapshot rather than an exception.
+    const { client } = makeClient(MINIMAL);
+    const snapshot = await collectSnapshot(client, REF, NOW);
+
+    expect(snapshot.identity.githubId).toBe(10270250);
+    expect(snapshot.identity.fullName).toBe('facebook/react');
+    expect(snapshot.collection.failures.length).toBeGreaterThan(0);
+  });
+
+  it('records each failed endpoint rather than discarding the reason', async () => {
+    const { client } = makeClient(MINIMAL);
+    const snapshot = await collectSnapshot(client, REF, NOW);
+
+    const resources = snapshot.collection.failures.map((f) => f.resource);
+    expect(resources).toContain('actions/workflows');
+    expect(snapshot.collection.failures.every((f) => f.reason === 'not_found')).toBe(
+      true,
+    );
+  });
+
+  it('propagates a rate limit rather than continuing with holes', async () => {
+    // Continuing after a rate limit would produce a snapshot that is mostly
+    // absent data and score it as though the absences were observations.
+    const { client } = makeClient({
+      [REPO]: ok(REPOSITORY),
+      [`${REPO}/contents`]: () =>
+        new Response(JSON.stringify({ message: 'rate limited' }), {
+          status: 403,
+          headers: {
+            'content-type': 'application/json',
+            'x-ratelimit-remaining': '0',
+            'x-ratelimit-reset': '1800000000',
+          },
+        }),
+    });
+
+    await expect(collectSnapshot(client, REF, NOW)).rejects.toMatchObject({
+      kind: 'rate_limited',
+    });
+  });
+
+  it('lets a repository-level failure reach the caller', async () => {
+    const { client } = makeClient({ [REPO]: status(404) });
+    await expect(collectSnapshot(client, REF, NOW)).rejects.toMatchObject({
+      kind: 'not_found',
+    });
+  });
+
+  it('keeps commit statistics null while GitHub is still computing them', async () => {
+    // A 202 means "not yet known". Recording it as zero commits would make an
+    // active repository look dead.
+    const { client } = makeClient({
+      [REPO]: ok(REPOSITORY),
+      [`${REPO}/stats/commit_activity`]: () => new Response(null, { status: 202 }),
+    });
+
+    const snapshot = await collectSnapshot(client, REF, NOW);
+    expect(snapshot.activity.weeklyCommits).toBeNull();
+  });
+
+  it('reads commit statistics when they are available', async () => {
+    const { client } = makeClient({
+      [REPO]: ok(REPOSITORY),
+      [`${REPO}/stats/commit_activity`]: ok([
+        { total: 5, week: 1 },
+        { total: 8, week: 2 },
+      ]),
+    });
+
+    const snapshot = await collectSnapshot(client, REF, NOW);
+    expect(snapshot.activity.weeklyCommits).toEqual([5, 8]);
+  });
+
+  it('leaves branch protection null when GitHub refuses the request', async () => {
+    // 403 here is the normal case for a repository the caller does not
+    // administer. "Unable to verify" must not become "not protected".
+    const { client } = makeClient({
+      [REPO]: ok(REPOSITORY),
+      [`${REPO}/branches/main/protection`]: status(403),
+    });
+
+    const snapshot = await collectSnapshot(client, REF, NOW);
+    expect(snapshot.community.defaultBranchProtected).toBeNull();
+  });
+
+  it('records branch protection when it is readable', async () => {
+    const { client } = makeClient({
+      [REPO]: ok(REPOSITORY),
+      [`${REPO}/branches/main/protection`]: ok({ enabled: true }),
+    });
+
+    const snapshot = await collectSnapshot(client, REF, NOW);
+    expect(snapshot.community.defaultBranchProtected).toBe(true);
+  });
+
+  it('returns a null issue snapshot when issues are disabled', async () => {
+    const { client } = makeClient({
+      [REPO]: ok({ ...REPOSITORY, has_issues: false }),
+    });
+
+    const snapshot = await collectSnapshot(client, REF, NOW);
+    expect(snapshot.issues).toBeNull();
+  });
+
+  it('counts contributors from the pagination header instead of enumerating them', async () => {
+    // per_page=1 makes the last page number equal the total count, turning an
+    // unbounded enumeration into a single request.
+    const { client, requested } = makeClient({
+      [REPO]: ok(REPOSITORY),
+      [`${REPO}/contributors`]: ok([{ login: 'a' }], {
+        link: '<https://api.github.com/repositories/1/contributors?per_page=1&page=1673>; rel="last"',
+      }),
+    });
+
+    const snapshot = await collectSnapshot(client, REF, NOW);
+    expect(snapshot.activity.contributorCount).toBe(1673);
+
+    const contributorCalls = requested.filter((url) => url.includes('/contributors'));
+    expect(contributorCalls).toHaveLength(1);
+  });
+
+  it('falls back to the returned length when there is no last link', async () => {
+    const { client } = makeClient({
+      [REPO]: ok(REPOSITORY),
+      [`${REPO}/contributors`]: ok([{ login: 'solo' }]),
+    });
+
+    const snapshot = await collectSnapshot(client, REF, NOW);
+    expect(snapshot.activity.contributorCount).toBe(1);
+  });
+
+  it('excludes pull requests returned by the issues endpoint', async () => {
+    const { client } = makeClient({
+      [REPO]: ok(REPOSITORY),
+      [`${REPO}/issues`]: ok([
+        {
+          number: 1,
+          state: 'open',
+          created_at: '2026-05-01T00:00:00Z',
+          updated_at: '2026-05-20T00:00:00Z',
+          closed_at: null,
+          html_url: 'https://github.com/facebook/react/issues/1',
+        },
+        {
+          number: 2,
+          state: 'open',
+          created_at: '2026-05-01T00:00:00Z',
+          updated_at: '2026-05-20T00:00:00Z',
+          closed_at: null,
+          html_url: 'https://github.com/facebook/react/pull/2',
+          pull_request: { url: 'https://api.github.com/…' },
+        },
+      ]),
+    });
+
+    const snapshot = await collectSnapshot(client, REF, NOW);
+    expect(snapshot.issues?.openCount).toBe(1);
+  });
+
+  it('detects security scanning from workflow file contents', async () => {
+    const { client } = makeClient({
+      [REPO]: ok(REPOSITORY),
+      [`${REPO}/contents/.github/workflows`]: ok([
+        {
+          name: 'codeql.yml',
+          path: '.github/workflows/codeql.yml',
+          type: 'file',
+          size: 500,
+          html_url: null,
+        },
+      ]),
+      [`${REPO}/contents/.github/workflows/codeql.yml`]: ok(
+        'uses: github/codeql-action/analyze@v3',
+      ),
+    });
+
+    const snapshot = await collectSnapshot(client, REF, NOW);
+    expect(snapshot.files.securityScanningWorkflows).toContain('github/codeql-action');
+  });
+
+  it('discards individual records that fail schema validation', async () => {
+    // One malformed record must not discard the whole collection.
+    const { client } = makeClient({
+      [REPO]: ok(REPOSITORY),
+      [`${REPO}/issues`]: ok([
+        { number: 'not-a-number', state: 'open' },
+        {
+          number: 2,
+          state: 'open',
+          created_at: '2026-05-01T00:00:00Z',
+          updated_at: '2026-05-20T00:00:00Z',
+          closed_at: null,
+          html_url: 'https://github.com/facebook/react/issues/2',
+        },
+      ]),
+    });
+
+    const snapshot = await collectSnapshot(client, REF, NOW);
+    expect(snapshot.issues?.openCount).toBe(1);
+  });
+
+  it('reports the requests spent so the cost of an analysis is visible', async () => {
+    const { client } = makeClient(MINIMAL);
+    const snapshot = await collectSnapshot(client, REF, NOW);
+    expect(snapshot.collection.requestsMade).toBeGreaterThan(0);
+    expect(snapshot.collection.requestsMade).toBe(client.budget.spent);
+  });
+
+  it('stamps the snapshot with the injected time, not the wall clock', async () => {
+    const { client } = makeClient(MINIMAL);
+    const snapshot = await collectSnapshot(client, REF, NOW);
+    expect(snapshot.capturedAt).toBe(NOW.toISOString());
+  });
+});

--- a/tests/unit/normalize/dates.test.ts
+++ b/tests/unit/normalize/dates.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  ageInDays,
+  daysBetween,
+  median,
+  parseDate,
+  proportionAtLeast,
+} from '@/lib/normalize/dates';
+
+const NOW = new Date('2026-06-01T00:00:00Z');
+
+describe('parseDate', () => {
+  it('parses a valid ISO timestamp', () => {
+    expect(parseDate('2026-05-01T00:00:00Z')?.toISOString()).toBe(
+      '2026-05-01T00:00:00.000Z',
+    );
+  });
+
+  it.each([
+    ['null', null],
+    ['undefined', undefined],
+    ['an empty string', ''],
+    ['a non-date string', 'not-a-date'],
+    ['a nonsense date', '2026-13-45T99:99:99Z'],
+  ])('returns null for %s rather than an invalid Date', (_label, input) => {
+    expect(parseDate(input)).toBeNull();
+  });
+});
+
+describe('daysBetween', () => {
+  it('counts whole days', () => {
+    expect(daysBetween(new Date('2026-05-01T00:00:00Z'), NOW)).toBe(31);
+  });
+
+  it('floors a partial day rather than rounding up', () => {
+    expect(daysBetween(new Date('2026-05-31T12:00:00Z'), NOW)).toBe(0);
+  });
+
+  it('clamps a future timestamp to zero instead of going negative', () => {
+    // Clock skew and scheduled releases both produce future timestamps. A
+    // negative age would compare strangely against every threshold.
+    expect(daysBetween(new Date('2026-07-01T00:00:00Z'), NOW)).toBe(0);
+  });
+});
+
+describe('ageInDays', () => {
+  it('measures age from an ISO timestamp', () => {
+    expect(ageInDays('2026-05-02T00:00:00Z', NOW)).toBe(30);
+  });
+
+  it.each([
+    ['null', null],
+    ['undefined', undefined],
+    ['an unparseable value', 'yesterday'],
+  ])('returns null for %s rather than NaN or zero', (_label, input) => {
+    // A NaN age silently compared against a threshold is exactly how
+    // "we don't know" becomes "it's bad".
+    expect(ageInDays(input, NOW)).toBeNull();
+  });
+});
+
+describe('median', () => {
+  it('returns null for an empty sample', () => {
+    expect(median([])).toBeNull();
+  });
+
+  it('returns the middle value of an odd-length sample', () => {
+    expect(median([5, 1, 3])).toBe(3);
+  });
+
+  it('averages the two middle values of an even-length sample', () => {
+    expect(median([1, 2, 3, 4])).toBe(2.5);
+  });
+
+  it('resists a single extreme outlier, unlike the mean', () => {
+    // This is why merge velocity uses the median: one four-year-old PR should
+    // not make a fast-merging project look slow.
+    const values = [1, 2, 2, 3, 1500];
+    expect(median(values)).toBe(2);
+  });
+
+  it('does not mutate its input', () => {
+    const values = [3, 1, 2];
+    median(values);
+    expect(values).toEqual([3, 1, 2]);
+  });
+
+  it('handles a single value', () => {
+    expect(median([7])).toBe(7);
+  });
+});
+
+describe('proportionAtLeast', () => {
+  it('returns null for an empty sample rather than zero', () => {
+    expect(proportionAtLeast([], 10)).toBeNull();
+  });
+
+  it('counts values at or above the threshold', () => {
+    expect(proportionAtLeast([1, 5, 10, 20], 10)).toBe(0.5);
+  });
+
+  it('includes the boundary value itself', () => {
+    expect(proportionAtLeast([10], 10)).toBe(1);
+  });
+
+  it('returns zero when nothing meets the threshold', () => {
+    expect(proportionAtLeast([1, 2, 3], 100)).toBe(0);
+  });
+});

--- a/tests/unit/normalize/snapshot.test.ts
+++ b/tests/unit/normalize/snapshot.test.ts
@@ -1,0 +1,592 @@
+import { describe, expect, it } from 'vitest';
+
+import type {
+  RawContentEntry,
+  RawIssue,
+  RawPullRequest,
+  RawRelease,
+  RawRepository,
+} from '@/lib/github/schemas';
+import {
+  detectLockfiles,
+  detectSecurityScanners,
+  excludePullRequests,
+  findFile,
+  normalizeCi,
+  normalizeCommunity,
+  normalizeConclusion,
+  normalizeFiles,
+  normalizeIdentity,
+  normalizeIssues,
+  normalizePullRequests,
+  normalizeReleases,
+} from '@/lib/normalize/snapshot';
+import type { SampleReport } from '@/types/snapshot';
+
+const NOW = new Date('2026-06-01T00:00:00Z');
+const COMPLETE: SampleReport = { examined: 10, truncated: false };
+
+/** Days before NOW, as an ISO string. */
+function daysAgo(days: number): string {
+  return new Date(NOW.getTime() - days * 86_400_000).toISOString();
+}
+
+function repository(overrides: Partial<RawRepository> = {}): RawRepository {
+  return {
+    id: 10270250,
+    name: 'react',
+    full_name: 'facebook/react',
+    owner: { login: 'facebook' },
+    html_url: 'https://github.com/facebook/react',
+    description: 'A JavaScript library for building user interfaces',
+    created_at: '2013-05-24T16:15:54Z',
+    pushed_at: daysAgo(1),
+    default_branch: 'main',
+    archived: false,
+    fork: false,
+    stargazers_count: 220_000,
+    forks_count: 45_000,
+    open_issues_count: 900,
+    has_issues: true,
+    homepage: 'https://react.dev',
+    topics: ['javascript', 'react'],
+    license: { spdx_id: 'MIT' },
+    ...overrides,
+  } as RawRepository;
+}
+
+function issue(overrides: Partial<RawIssue> = {}): RawIssue {
+  return {
+    number: 1,
+    state: 'open',
+    created_at: daysAgo(10),
+    updated_at: daysAgo(5),
+    closed_at: null,
+    html_url: 'https://github.com/facebook/react/issues/1',
+    ...overrides,
+  } as RawIssue;
+}
+
+function pull(overrides: Partial<RawPullRequest> = {}): RawPullRequest {
+  return {
+    number: 1,
+    state: 'open',
+    created_at: daysAgo(10),
+    updated_at: daysAgo(5),
+    closed_at: null,
+    merged_at: null,
+    draft: false,
+    html_url: 'https://github.com/facebook/react/pull/1',
+    ...overrides,
+  } as RawPullRequest;
+}
+
+function file(name: string, size = 1000, type = 'file'): RawContentEntry {
+  return {
+    name,
+    path: name,
+    type,
+    size,
+    html_url: `https://github.com/facebook/react/blob/main/${name}`,
+  };
+}
+
+describe('normalizeIdentity', () => {
+  it('keys identity on the immutable numeric id', () => {
+    const identity = normalizeIdentity(repository());
+    expect(identity.githubId).toBe(10270250);
+    expect(identity.fullName).toBe('facebook/react');
+    expect(identity.defaultBranch).toBe('main');
+  });
+
+  it('preserves a null description rather than substituting a string', () => {
+    expect(normalizeIdentity(repository({ description: null })).description).toBeNull();
+  });
+});
+
+describe('excludePullRequests — the issues/PRs regression', () => {
+  it('removes any payload carrying a pull_request key', () => {
+    // GitHub's /issues endpoints return PRs alongside issues. Failing to
+    // filter inflates every issue metric on any repository taking
+    // contributions, which is most of them.
+    const mixed: RawIssue[] = [
+      issue({ number: 1 }),
+      issue({ number: 2, pull_request: { url: 'https://api.github.com/…' } }),
+      issue({ number: 3 }),
+      issue({ number: 4, pull_request: {} }),
+    ];
+
+    const result = excludePullRequests(mixed);
+    expect(result.map((i) => i.number)).toEqual([1, 3]);
+  });
+
+  it('keeps issues whose pull_request key is explicitly null', () => {
+    const raws = [issue({ number: 1, pull_request: null })];
+    expect(excludePullRequests(raws)).toHaveLength(1);
+  });
+
+  it('does not affect a list containing no pull requests', () => {
+    const raws = [issue({ number: 1 }), issue({ number: 2 })];
+    expect(excludePullRequests(raws)).toHaveLength(2);
+  });
+});
+
+describe('normalizeIssues', () => {
+  it('returns null when issues are disabled, not a zero backlog', () => {
+    // This is the difference between "not applicable" and "no issues", and
+    // the whole reason the field is nullable.
+    const result = normalizeIssues({
+      raws: [],
+      sample: COMPLETE,
+      hasIssuesEnabled: false,
+      now: NOW,
+    });
+    expect(result).toBeNull();
+  });
+
+  it('returns a zero-count snapshot when issues are enabled but empty', () => {
+    const result = normalizeIssues({
+      raws: [],
+      sample: COMPLETE,
+      hasIssuesEnabled: true,
+      now: NOW,
+    });
+    expect(result).not.toBeNull();
+    expect(result?.openCount).toBe(0);
+  });
+
+  it('excludes pull requests from the open count', () => {
+    const result = normalizeIssues({
+      raws: [issue({ number: 1 }), issue({ number: 2, pull_request: {} })],
+      sample: COMPLETE,
+      hasIssuesEnabled: true,
+      now: NOW,
+    });
+    expect(result?.openCount).toBe(1);
+  });
+
+  it('sorts age and inactivity ascending', () => {
+    const result = normalizeIssues({
+      raws: [
+        issue({ number: 1, created_at: daysAgo(300), updated_at: daysAgo(200) }),
+        issue({ number: 2, created_at: daysAgo(10), updated_at: daysAgo(2) }),
+        issue({ number: 3, created_at: daysAgo(100), updated_at: daysAgo(50) }),
+      ],
+      sample: COMPLETE,
+      hasIssuesEnabled: true,
+      now: NOW,
+    });
+    expect(result?.openAgeDays).toEqual([10, 100, 300]);
+    expect(result?.openInactiveDays).toEqual([2, 50, 200]);
+  });
+
+  it('counts creations and closures within the trailing 90 days', () => {
+    const result = normalizeIssues({
+      raws: [
+        issue({ number: 1, created_at: daysAgo(30) }),
+        issue({ number: 2, created_at: daysAgo(200) }),
+        issue({
+          number: 3,
+          state: 'closed',
+          created_at: daysAgo(120),
+          closed_at: daysAgo(10),
+        }),
+        issue({
+          number: 4,
+          state: 'closed',
+          created_at: daysAgo(400),
+          closed_at: daysAgo(300),
+        }),
+      ],
+      sample: COMPLETE,
+      hasIssuesEnabled: true,
+      now: NOW,
+    });
+    expect(result?.createdLast90Days).toBe(1);
+    expect(result?.closedLast90Days).toBe(1);
+  });
+
+  it('carries the sample report through so confidence can be lowered', () => {
+    const truncated: SampleReport = { examined: 200, truncated: true };
+    const result = normalizeIssues({
+      raws: [issue()],
+      sample: truncated,
+      hasIssuesEnabled: true,
+      now: NOW,
+    });
+    expect(result?.sample.truncated).toBe(true);
+  });
+
+  it('skips issues whose timestamps are unparseable rather than counting them as zero-age', () => {
+    const result = normalizeIssues({
+      raws: [issue({ number: 1, created_at: 'not-a-date', updated_at: 'nope' })],
+      sample: COMPLETE,
+      hasIssuesEnabled: true,
+      now: NOW,
+    });
+    expect(result?.openCount).toBe(1);
+    expect(result?.openAgeDays).toEqual([]);
+  });
+});
+
+describe('normalizePullRequests', () => {
+  it('returns null when the repository has never had a pull request', () => {
+    expect(normalizePullRequests({ raws: [], sample: COMPLETE, now: NOW })).toBeNull();
+  });
+
+  it('computes merge duration from creation to merge', () => {
+    const result = normalizePullRequests({
+      raws: [pull({ created_at: daysAgo(20), merged_at: daysAgo(15), state: 'closed' })],
+      sample: COMPLETE,
+      now: NOW,
+    });
+    expect(result?.mergedDurationDays).toEqual([5]);
+  });
+
+  it('separates recently merged from recently closed-unmerged', () => {
+    const result = normalizePullRequests({
+      raws: [
+        pull({
+          number: 1,
+          created_at: daysAgo(40),
+          merged_at: daysAgo(30),
+          state: 'closed',
+        }),
+        pull({
+          number: 2,
+          created_at: daysAgo(40),
+          closed_at: daysAgo(30),
+          state: 'closed',
+        }),
+        pull({
+          number: 3,
+          created_at: daysAgo(400),
+          merged_at: daysAgo(300),
+          state: 'closed',
+        }),
+      ],
+      sample: COMPLETE,
+      now: NOW,
+    });
+    expect(result?.recentlyMergedCount).toBe(1);
+    expect(result?.recentlyClosedUnmergedCount).toBe(1);
+  });
+
+  it('counts only open PRs in the open count and age distribution', () => {
+    const result = normalizePullRequests({
+      raws: [
+        pull({ number: 1, state: 'open', created_at: daysAgo(5) }),
+        pull({
+          number: 2,
+          state: 'closed',
+          merged_at: daysAgo(1),
+          created_at: daysAgo(3),
+        }),
+      ],
+      sample: COMPLETE,
+      now: NOW,
+    });
+    expect(result?.openCount).toBe(1);
+    expect(result?.openAgeDays).toEqual([5]);
+  });
+
+  it('never produces a negative merge duration from skewed timestamps', () => {
+    const result = normalizePullRequests({
+      raws: [pull({ created_at: daysAgo(5), merged_at: daysAgo(10), state: 'closed' })],
+      sample: COMPLETE,
+      now: NOW,
+    });
+    expect(result?.mergedDurationDays.every((d) => d >= 0)).toBe(true);
+  });
+});
+
+describe('normalizeReleases', () => {
+  const release = (overrides: Partial<RawRelease> = {}): RawRelease =>
+    ({
+      tag_name: 'v1.0.0',
+      published_at: daysAgo(30),
+      prerelease: false,
+      draft: false,
+      html_url: 'https://github.com/facebook/react/releases/tag/v1.0.0',
+      ...overrides,
+    }) as RawRelease;
+
+  it('excludes drafts, which are invisible to users', () => {
+    const result = normalizeReleases([
+      release({ tag_name: 'v1.0.0' }),
+      release({ tag_name: 'v2.0.0-draft', draft: true }),
+    ]);
+    expect(result.map((r) => r.tagName)).toEqual(['v1.0.0']);
+  });
+
+  it('keeps prereleases but marks them', () => {
+    const result = normalizeReleases([
+      release({ tag_name: 'v2.0.0-rc.1', prerelease: true }),
+    ]);
+    expect(result[0]?.isPrerelease).toBe(true);
+  });
+});
+
+describe('normalizeConclusion', () => {
+  it.each([
+    ['success', 'success'],
+    ['failure', 'failure'],
+    ['cancelled', 'cancelled'],
+    ['skipped', 'skipped'],
+    ['timed_out', 'timed_out'],
+  ])('passes through the known conclusion %s', (input, expected) => {
+    expect(normalizeConclusion(input)).toBe(expected);
+  });
+
+  it.each([
+    ['null, meaning still running', null],
+    ['an unrecognized value', 'some_new_conclusion_github_added'],
+  ])('maps %s to unknown rather than guessing', (_label, input) => {
+    expect(normalizeConclusion(input)).toBe('unknown');
+  });
+});
+
+describe('normalizeCi', () => {
+  it('preserves a null workflow count as unknown, not as zero workflows', () => {
+    // The distinction that matters most in this category: unreadable CI data
+    // is not the same as a repository with no CI.
+    const result = normalizeCi({
+      workflowCount: null,
+      workflowFileNames: [],
+      runConclusions: [],
+      latestCommitStatus: null,
+      sample: COMPLETE,
+    });
+    expect(result.workflowCount).toBeNull();
+  });
+
+  it('records zero workflows distinctly from unknown', () => {
+    const result = normalizeCi({
+      workflowCount: 0,
+      workflowFileNames: [],
+      runConclusions: [],
+      latestCommitStatus: null,
+      sample: COMPLETE,
+    });
+    expect(result.workflowCount).toBe(0);
+  });
+
+  it.each([
+    ['success', 'success'],
+    ['failure', 'failure'],
+    ['pending', 'pending'],
+  ])('passes through commit status %s', (input, expected) => {
+    const result = normalizeCi({
+      workflowCount: 1,
+      workflowFileNames: ['ci.yml'],
+      runConclusions: [],
+      latestCommitStatus: input,
+      sample: COMPLETE,
+    });
+    expect(result.latestCommitStatus).toBe(expected);
+  });
+
+  it('maps an unrecognized commit status to none rather than inventing one', () => {
+    const result = normalizeCi({
+      workflowCount: 1,
+      workflowFileNames: [],
+      runConclusions: [],
+      latestCommitStatus: 'something_else',
+      sample: COMPLETE,
+    });
+    expect(result.latestCommitStatus).toBe('none');
+  });
+});
+
+describe('findFile', () => {
+  const entries = [
+    file('README.md'),
+    file('LICENSE'),
+    file('src', 0, 'dir'),
+    file('package.json'),
+  ];
+
+  it('matches case-insensitively', () => {
+    expect(findFile(entries, ['readme']).present).toBe(true);
+  });
+
+  it('matches a stem with any extension', () => {
+    expect(findFile([file('CONTRIBUTING.rst')], ['contributing']).present).toBe(true);
+  });
+
+  it('matches an extensionless file', () => {
+    expect(findFile(entries, ['license']).present).toBe(true);
+  });
+
+  it('accepts any of several spellings', () => {
+    expect(findFile([file('LICENCE.txt')], ['license', 'licence']).present).toBe(true);
+  });
+
+  it('does not match a directory of the same name', () => {
+    expect(findFile([file('docs', 0, 'dir')], ['docs']).present).toBe(false);
+  });
+
+  it('reports absence with nulls rather than zeros', () => {
+    const result = findFile(entries, ['security']);
+    expect(result).toEqual({
+      present: false,
+      path: null,
+      sizeBytes: null,
+      htmlUrl: null,
+    });
+  });
+
+  it('captures size so a stub can be told from a substantial file', () => {
+    expect(findFile([file('README.md', 42)], ['readme']).sizeBytes).toBe(42);
+  });
+});
+
+describe('detectLockfiles', () => {
+  it.each([
+    ['npm', 'package-lock.json'],
+    ['yarn', 'yarn.lock'],
+    ['pnpm', 'pnpm-lock.yaml'],
+    ['bun', 'bun.lockb'],
+    ['poetry', 'poetry.lock'],
+    ['cargo', 'Cargo.lock'],
+    ['go', 'go.sum'],
+    ['bundler', 'Gemfile.lock'],
+    ['composer', 'composer.lock'],
+  ])('detects the %s lockfile', (_label, name) => {
+    expect(detectLockfiles([file(name)])).toEqual([name]);
+  });
+
+  it('ignores non-lockfiles', () => {
+    expect(detectLockfiles([file('package.json'), file('README.md')])).toEqual([]);
+  });
+
+  it('ignores a directory that shares a lockfile name', () => {
+    expect(detectLockfiles([file('go.sum', 0, 'dir')])).toEqual([]);
+  });
+});
+
+describe('detectSecurityScanners', () => {
+  it.each([
+    ['CodeQL', 'uses: github/codeql-action/analyze@v3'],
+    ['Trivy', 'uses: aquasecurity/trivy-action@master'],
+    ['Snyk', 'uses: snyk/actions/node@master'],
+    ['Semgrep', 'uses: semgrep/semgrep-action@v1'],
+    ['npm audit', 'run: npm audit --audit-level=high'],
+    ['gitleaks', 'uses: gitleaks/gitleaks-action@v2'],
+  ])('detects %s in workflow text', (_label, content) => {
+    expect(detectSecurityScanners([content]).length).toBeGreaterThan(0);
+  });
+
+  it('finds nothing in a workflow without scanning', () => {
+    expect(detectSecurityScanners(['run: npm test'])).toEqual([]);
+  });
+
+  it('deduplicates a scanner used across several workflows', () => {
+    const result = detectSecurityScanners([
+      'uses: github/codeql-action/init@v3',
+      'uses: github/codeql-action/analyze@v3',
+    ]);
+    expect(result).toEqual(['github/codeql-action']);
+  });
+
+  it('handles an empty workflow list', () => {
+    expect(detectSecurityScanners([])).toEqual([]);
+  });
+});
+
+describe('normalizeFiles', () => {
+  const base = {
+    rootEntries: [],
+    githubDirEntries: [],
+    hasIssueTemplates: false,
+    hasPullRequestTemplate: false,
+    workflowContents: [],
+  };
+
+  it('finds health files at the repository root', () => {
+    const result = normalizeFiles({
+      ...base,
+      rootEntries: [file('README.md'), file('LICENSE'), file('CONTRIBUTING.md')],
+    });
+    expect(result.readme.present).toBe(true);
+    expect(result.license.present).toBe(true);
+    expect(result.contributing.present).toBe(true);
+  });
+
+  it('also finds health files inside .github', () => {
+    // GitHub honours both locations, so checking only the root would report a
+    // documented project as undocumented.
+    const result = normalizeFiles({
+      ...base,
+      githubDirEntries: [file('CONTRIBUTING.md'), file('SECURITY.md')],
+    });
+    expect(result.contributing.present).toBe(true);
+    expect(result.security.present).toBe(true);
+  });
+
+  it('prefers the root copy when a file exists in both locations', () => {
+    const result = normalizeFiles({
+      ...base,
+      rootEntries: [file('CONTRIBUTING.md', 5000)],
+      githubDirEntries: [file('CONTRIBUTING.md', 100)],
+    });
+    expect(result.contributing.sizeBytes).toBe(5000);
+  });
+
+  it.each([
+    ['dependabot', { githubDirEntries: [file('dependabot.yml')] }],
+    ['renovate at the root', { rootEntries: [file('renovate.json')] }],
+    ['renovate in .github', { githubDirEntries: [file('renovate.json')] }],
+    ['a dotfile renovate config', { rootEntries: [file('.renovaterc.json')] }],
+  ])('detects dependency automation via %s', (_label, overrides) => {
+    const result = normalizeFiles({ ...base, ...overrides });
+    expect(result.dependencyAutomation.present).toBe(true);
+  });
+
+  it('finds a docs directory but not a docs file', () => {
+    expect(
+      normalizeFiles({ ...base, rootEntries: [file('docs', 0, 'dir')] }).docsDirectory
+        .present,
+    ).toBe(true);
+    expect(
+      normalizeFiles({ ...base, rootEntries: [file('docs.md')] }).docsDirectory.present,
+    ).toBe(false);
+  });
+
+  it('reports every file absent for an empty repository', () => {
+    const result = normalizeFiles(base);
+    expect(result.readme.present).toBe(false);
+    expect(result.license.present).toBe(false);
+    expect(result.lockfiles).toEqual([]);
+    expect(result.securityScanningWorkflows).toEqual([]);
+  });
+});
+
+describe('normalizeCommunity', () => {
+  it('treats a whitespace-only description as absent', () => {
+    const result = normalizeCommunity({
+      repository: repository({ description: '   ' }),
+      defaultBranchProtected: null,
+    });
+    expect(result.hasDescription).toBe(false);
+  });
+
+  it('preserves unreadable branch protection as null, not false', () => {
+    // Branch protection needs elevated permissions on most repositories.
+    // Reporting "unknown" as "not protected" would penalize a repository for
+    // a permission RepoSignal does not have.
+    const result = normalizeCommunity({
+      repository: repository(),
+      defaultBranchProtected: null,
+    });
+    expect(result.defaultBranchProtected).toBeNull();
+  });
+
+  it('records protection when it is actually readable', () => {
+    const result = normalizeCommunity({
+      repository: repository(),
+      defaultBranchProtected: true,
+    });
+    expect(result.defaultBranchProtected).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Turns GitHub payloads into a `RepositorySnapshot` — the single input the scoring engine will ever see — plus the collector that assembles one.

Closes #10

## Why

This is the boundary that keeps GitHub's vocabulary out of the domain. Everything downstream depends on types this project owns, so scoring can be tested with plain object literals instead of recorded HTTP fixtures, and a GitHub API change is contained to this directory.

## Changes

### Pull requests are excluded from all issue data

GitHub's `/issues` endpoints return pull requests alongside issues. The only reliable discriminator is the presence of a `pull_request` key. Missing this inflates every issue metric on any repository that takes contributions — which is most of them. There is a dedicated regression test, and a second one at the collector level.

### Unobservable stays null

Three distinct cases that would each be wrong as a zero:

| Observation | Naive reading | What RepoSignal records |
| --- | --- | --- |
| `stats/commit_activity` returns `202` | 0 commits | `null` — GitHub is still computing |
| `branches/*/protection` returns `403` | Not protected | `null` — unable to verify |
| `has_issues: false` | Empty backlog | `null` — not applicable |

The first would make an active repository look dead. The second would penalize a repository for a permission RepoSignal doesn't have.

### Partial collection is the normal case

Only the repository endpoint is required. Every other endpoint may fail, recording a `CollectionReport` entry and leaving its field `null` — a repository whose workflow runs are unreadable still deserves a documentation score.

Rate limits are the one exception and are rethrown. Continuing past one produces a snapshot that is mostly holes and then scores it as though the holes were observations.

### Truncation flows through

Samples carry a `SampleReport` so scoring can lower confidence for anything derived from a partial view.

### Counting without enumerating

Contributor and tag counts issue one `per_page=1` request and read the total from the `last` pagination link. React has ~1,600 contributors; enumerating them would be 16 requests, and this is one.

## Testing

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test` — 200 passing
- [x] `npm run build`

```
File          | % Stmts | % Branch | % Funcs | % Lines
--------------|---------|----------|---------|--------
All files     |   95.04 |    87.22 |   87.75 |   95.61
 normalize    |   98.56 |    91.76 |   97.43 |   99.15
```

Two bugs were caught by the tests while writing them, both in the test harness rather than the product: a helper that accepted overrides without applying them, and a route matcher where `repos/facebook/react` is a prefix of every other endpoint and so swallowed the entire collection.

## Risks

Security-scanner detection is substring matching against workflow text, so it can produce a false positive if a scanner name appears in a comment. It is deliberately not a YAML parse — RepoSignal never evaluates repository content — and the failure mode is a slightly generous Security Hygiene signal rather than an incorrect claim.

Workflow contents are read for at most 5 files, to bound request cost. A repository with scanning declared only in a 6th workflow would be missed; this is recorded as sample truncation.

## Checklist

- [x] Scope matches the linked issue
- [x] Tests cover the new behavior, including null and partial-data paths
- [x] No scoring rules changed, so no version bump required
- [x] No secrets, tokens, or personal data added to the repository or logs
- [x] Documentation updated where behavior changed (CHANGELOG)