### PR TITLE
feat: implement the scoring engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ analysis records the `scoringVersion` it was produced under.
 
 ### Added
 
+- Scoring engine (`scoringVersion` 1.0.0): seven pure category scorers —
+  activity, pull requests, issues, CI, documentation, repository hygiene, and
+  security hygiene — plus the overall engine that renormalizes declared weights
+  across whichever categories produced a score. Null categories are excluded
+  and their weight redistributed; they never count as zero
 - Repository normalization layer: Zod-parsed GitHub payloads mapped into a
   `RepositorySnapshot`, with pull requests excluded from all issue data,
   unobservable values preserved as `null`, sample truncation recorded, and

--- a/src/lib/scoring/activity.ts
+++ b/src/lib/scoring/activity.ts
@@ -1,0 +1,317 @@
+import { ageInDays, parseDate } from '@/lib/normalize/dates';
+import type { CategoryScore, Finding } from '@/types/analysis';
+import type { RepositorySnapshot } from '@/types/snapshot';
+
+import {
+  combine,
+  component,
+  describeFormula,
+  deriveConfidence,
+  metric,
+  scoreDescending,
+} from './primitives';
+import { CATEGORY_LABELS } from './weights';
+
+/**
+ * Repository activity scoring.
+ *
+ * Two things this module is careful about:
+ *
+ * 1. **Archived repositories are not neglected repositories.** Archiving is a
+ *    deliberate act that says "this is finished". Scoring an archived project
+ *    as inactive would punish a maintainer for closing something down
+ *    responsibly, so activity components are excluded and the category
+ *    reports on the archival instead.
+ *
+ * 2. **Unavailable commit statistics are not zero commits.** GitHub computes
+ *    them asynchronously and answers 202 until they are ready. Treating that
+ *    as no activity would make a busy repository look dead.
+ */
+
+/** Bands for days since the last push. Lower is better. */
+const LAST_PUSH_BANDS = [
+  { upTo: 30, score: 100, label: 'Pushed within a month' },
+  { upTo: 90, score: 85, label: 'Pushed within 3 months' },
+  { upTo: 180, score: 65, label: 'Pushed within 6 months' },
+  { upTo: 365, score: 40, label: 'Pushed within a year' },
+  { upTo: Infinity, score: 15, label: 'No push in over a year' },
+];
+
+/** Bands for days since the most recent release. Lower is better. */
+const LAST_RELEASE_BANDS = [
+  { upTo: 90, score: 100, label: 'Released within 3 months' },
+  { upTo: 180, score: 85, label: 'Released within 6 months' },
+  { upTo: 365, score: 65, label: 'Released within a year' },
+  { upTo: 730, score: 40, label: 'Released within 2 years' },
+  { upTo: Infinity, score: 20, label: 'No release in over 2 years' },
+];
+
+/** Releases needed before cadence regularity means anything. */
+export const MINIMUM_RELEASES_FOR_CADENCE = 3;
+
+/** Weeks of the trailing year with at least one commit, as a proportion. */
+function activeWeekRatio(weeklyCommits: number[] | null): number | null {
+  if (weeklyCommits === null || weeklyCommits.length === 0) return null;
+  return weeklyCommits.filter((count) => count > 0).length / weeklyCommits.length;
+}
+
+/**
+ * Regularity of release intervals, as a 0–100 score.
+ *
+ * Uses the coefficient of variation — standard deviation over mean — so it
+ * measures consistency independent of how often a project releases. A project
+ * releasing every 6 months predictably scores as well as one releasing weekly.
+ *
+ * Returns `null` below three releases, since two releases give exactly one
+ * interval and one interval has no variation to measure.
+ */
+export function releaseCadenceScore(publishedDates: Date[]): number | null {
+  if (publishedDates.length < MINIMUM_RELEASES_FOR_CADENCE) return null;
+
+  const sorted = [...publishedDates].sort((a, b) => a.getTime() - b.getTime());
+  const intervals: number[] = [];
+  for (let i = 1; i < sorted.length; i += 1) {
+    const previous = sorted[i - 1];
+    const current = sorted[i];
+    if (previous === undefined || current === undefined) continue;
+    intervals.push((current.getTime() - previous.getTime()) / 86_400_000);
+  }
+
+  if (intervals.length === 0) return null;
+
+  const mean = intervals.reduce((sum, v) => sum + v, 0) / intervals.length;
+  if (mean === 0) return null;
+
+  const variance =
+    intervals.reduce((sum, v) => sum + (v - mean) ** 2, 0) / intervals.length;
+  const coefficientOfVariation = Math.sqrt(variance) / mean;
+
+  // CV of 0 is perfectly regular; 1.5 or above is effectively arbitrary.
+  return Math.round(Math.max(0, Math.min(1, 1 - coefficientOfVariation / 1.5)) * 100);
+}
+
+export function scoreActivity(snapshot: RepositorySnapshot, now: Date): CategoryScore {
+  const activity = snapshot.activity;
+  const repoUrl = snapshot.identity.htmlUrl;
+
+  const daysSincePush = ageInDays(activity.pushedAt, now);
+  const publishedDates = activity.releases
+    .map((release) => parseDate(release.publishedAt))
+    .filter((date): date is Date => date !== null);
+
+  const latestRelease = publishedDates.reduce<Date | null>(
+    (latest, date) => (latest === null || date > latest ? date : latest),
+    null,
+  );
+  const daysSinceRelease =
+    latestRelease === null ? null : ageInDays(latestRelease.toISOString(), now);
+
+  const weekRatio = activeWeekRatio(activity.weeklyCommits);
+  const cadence = releaseCadenceScore(publishedDates);
+
+  const push = scoreDescending(daysSincePush, LAST_PUSH_BANDS);
+  const release = scoreDescending(daysSinceRelease, LAST_RELEASE_BANDS);
+
+  const findings: Finding[] = [];
+
+  // An archived repository is finished, not failing. Activity components are
+  // excluded and the category is scored on what remains.
+  if (activity.isArchived) {
+    findings.push({
+      id: 'activity.archived',
+      category: 'activity',
+      severity: 'info',
+      title: 'Repository is archived',
+      explanation:
+        'The maintainers have archived this repository, marking it read-only and no longer maintained. Recency of activity is not a meaningful signal for an archived project, so it was excluded from this score rather than counted against it.',
+      metric: { archived: 'true' },
+      recommendation:
+        'If you depend on this project, look for a maintained fork or a documented successor.',
+      confidence: 'high',
+      evidenceUrl: repoUrl,
+    });
+  }
+
+  const components = activity.isArchived
+    ? [
+        component(
+          'activity.releases',
+          'Release history',
+          activity.releases.length > 0 ? 100 : 0,
+          50,
+          `${activity.releases.length} published release${activity.releases.length === 1 ? '' : 's'}`,
+          'An archived repository is scored on what it left behind: at least one release scores 100.',
+        ),
+        component(
+          'activity.cadence',
+          'Release cadence regularity',
+          cadence,
+          50,
+          cadence === null
+            ? `Fewer than ${MINIMUM_RELEASES_FOR_CADENCE} releases — not measurable`
+            : `Regularity score ${cadence}`,
+          `Coefficient of variation of intervals between releases. Null below ${MINIMUM_RELEASES_FOR_CADENCE} releases.`,
+        ),
+      ]
+    : [
+        component(
+          'activity.lastPush',
+          'Time since last push',
+          push.score,
+          35,
+          daysSincePush === null
+            ? 'No push timestamp available'
+            : `${daysSincePush} days ago`,
+          `Days since the most recent push. ${push.label}.`,
+        ),
+        component(
+          'activity.commitCadence',
+          'Weeks with commits',
+          weekRatio === null ? null : Math.round(weekRatio * 100),
+          25,
+          weekRatio === null
+            ? 'GitHub has not made commit statistics available'
+            : `${Math.round(weekRatio * 100)}% of the last ${activity.weeklyCommits?.length ?? 0} weeks had commits`,
+          'Proportion of the trailing year’s weeks containing at least one commit. Unavailable statistics score null and the weight is redistributed.',
+        ),
+        component(
+          'activity.lastRelease',
+          'Time since last release',
+          release.score,
+          25,
+          daysSinceRelease === null
+            ? 'No published releases'
+            : `${daysSinceRelease} days ago`,
+          `Days since the most recent published release. ${release.label}.`,
+        ),
+        component(
+          'activity.cadence',
+          'Release cadence regularity',
+          cadence,
+          15,
+          cadence === null
+            ? `Fewer than ${MINIMUM_RELEASES_FOR_CADENCE} releases — not measurable`
+            : `Regularity score ${cadence}`,
+          `Coefficient of variation of intervals between releases, so a predictable slow cadence scores as well as a predictable fast one. Null below ${MINIMUM_RELEASES_FOR_CADENCE} releases.`,
+        ),
+      ];
+
+  const { score, scoredWeight, totalWeight } = combine(components);
+
+  if (!activity.isArchived && daysSincePush !== null && daysSincePush > 365) {
+    findings.push({
+      id: 'activity.inactive',
+      category: 'activity',
+      severity: 'high',
+      title: 'No commits pushed in over a year',
+      explanation: `The most recent push was ${daysSincePush} days ago. The repository is not archived, so it is presented as maintained, but nothing has been committed in over a year.`,
+      metric: { daysSinceLastPush: daysSincePush },
+      recommendation:
+        'If you depend on this project, check whether it is still maintained before relying on future fixes.',
+      confidence: 'high',
+      evidenceUrl: `${repoUrl}/commits`,
+    });
+  } else if (!activity.isArchived && daysSincePush !== null && daysSincePush > 180) {
+    findings.push({
+      id: 'activity.slowing',
+      category: 'activity',
+      severity: 'medium',
+      title: 'No commits pushed in over six months',
+      explanation: `The most recent push was ${daysSincePush} days ago. For a stable, finished library this can be entirely normal; for one still under development it is not.`,
+      metric: { daysSinceLastPush: daysSincePush },
+      recommendation: 'No action implied — this is context for evaluating the project.',
+      confidence: 'high',
+      evidenceUrl: `${repoUrl}/commits`,
+    });
+  }
+
+  if (activity.releases.length === 0 && !activity.isArchived) {
+    findings.push({
+      id: 'activity.releases.none',
+      category: 'activity',
+      severity: 'low',
+      title: 'No published releases',
+      explanation:
+        'The repository has no published releases, so consumers have no versioned artifact to depend on and no record of what changed between points in time.',
+      metric: { releaseCount: 0 },
+      recommendation:
+        'Publish releases at meaningful points so consumers can pin a version.',
+      confidence: 'high',
+      evidenceUrl: `${repoUrl}/releases`,
+    });
+  }
+
+  if (cadence !== null && cadence < 40) {
+    findings.push({
+      id: 'activity.cadence.irregular',
+      category: 'activity',
+      severity: 'info',
+      title: 'Release cadence is irregular',
+      explanation: `Intervals between the ${publishedDates.length} published releases vary widely. Irregular releases make it harder to anticipate when a fix will ship, though many healthy projects release when there is something worth releasing rather than on a schedule.`,
+      metric: { cadenceScore: cadence, releasesExamined: publishedDates.length },
+      recommendation: 'No action implied.',
+      confidence: 'medium',
+      evidenceUrl: `${repoUrl}/releases`,
+    });
+  }
+
+  const limitations = [
+    'Activity measures visible timestamps, not effort. A single automated commit and a substantial feature look identical here.',
+    'Recent activity is not the same as quality, and inactivity is not the same as abandonment — a small, finished library may correctly go years without a commit.',
+  ];
+
+  if (activity.weeklyCommits === null) {
+    limitations.push(
+      'GitHub had not finished computing commit statistics for this repository, so commit cadence could not be measured. It was excluded from the score rather than treated as zero commits.',
+    );
+  }
+
+  if (activity.contributorCount === null) {
+    limitations.push(
+      'GitHub declined to enumerate contributors for this repository, so contributor count is unknown.',
+    );
+  }
+
+  return {
+    key: 'activity',
+    label: CATEGORY_LABELS.activity,
+    score,
+    confidence: deriveConfidence({ scoredWeight, totalWeight }),
+    metrics: [
+      metric('activity.lastPush.days', 'Days since last push', daysSincePush, {
+        unit: 'days',
+        unknownReason: 'not_retrieved',
+      }),
+      metric(
+        'activity.commitWeeks.ratio',
+        'Weeks with commits',
+        weekRatio === null ? null : Math.round(weekRatio * 100),
+        {
+          unit: '%',
+          unknownReason: 'not_retrieved',
+        },
+      ),
+      metric('activity.releases.count', 'Published releases', activity.releases.length),
+      metric('activity.lastRelease.days', 'Days since last release', daysSinceRelease, {
+        unit: 'days',
+        unknownReason: 'not_applicable',
+      }),
+      metric('activity.cadence.score', 'Release cadence regularity', cadence, {
+        unknownReason: 'insufficient_data',
+      }),
+      metric('activity.contributors.count', 'Contributors', activity.contributorCount, {
+        unknownReason: 'not_retrieved',
+      }),
+      metric('activity.archived', 'Archived', String(activity.isArchived)),
+    ],
+    findings,
+    explanation: {
+      summary: activity.isArchived
+        ? 'This repository is archived, so recency was excluded and it is scored on the release history it left behind.'
+        : 'Measures whether the project is being actively developed: how recently it was pushed to, how consistently it is committed to, and how recently and regularly it releases.',
+      formula: describeFormula(components),
+      components,
+      limitations,
+    },
+  };
+}

--- a/src/lib/scoring/ci.ts
+++ b/src/lib/scoring/ci.ts
@@ -1,0 +1,305 @@
+import type { CategoryScore, Finding } from '@/types/analysis';
+import type { RepositorySnapshot, WorkflowConclusion } from '@/types/snapshot';
+
+import {
+  combine,
+  component,
+  describeFormula,
+  deriveConfidence,
+  metric,
+} from './primitives';
+import { CATEGORY_LABELS } from './weights';
+
+/**
+ * CI health scoring.
+ *
+ * This is the category where an unavailability-means-failure bug would do the
+ * most damage, so the distinctions are drawn explicitly:
+ *
+ * - **Unreadable CI data** → `null`. Not a failure.
+ * - **No CI configured** → a configuration finding, scored on the absence of
+ *   configuration. Clearly distinct from configured-but-failing.
+ * - **Configured and failing** → a run-outcome finding.
+ *
+ * `cancelled` and `skipped` runs are excluded from the success rate rather
+ * than counted as failures. A cancelled run is a superseded run, and counting
+ * it as a failure would penalize exactly the projects that cancel outdated
+ * runs to save CI minutes.
+ */
+
+/** Consecutive failures on the default branch before it is worth reporting. */
+export const CONSECUTIVE_FAILURE_THRESHOLD = 3;
+
+/** Conclusions that represent a real pass/fail signal. */
+const DECISIVE: WorkflowConclusion[] = [
+  'success',
+  'failure',
+  'timed_out',
+  'startup_failure',
+];
+
+const SUCCESSFUL: WorkflowConclusion[] = ['success'];
+
+/** Leading failures in a newest-first run list. */
+export function countLeadingFailures(conclusions: WorkflowConclusion[]): number {
+  let count = 0;
+  for (const conclusion of conclusions) {
+    // Skipped and cancelled runs neither break nor continue a failure streak.
+    if (conclusion === 'skipped' || conclusion === 'cancelled') continue;
+    if (DECISIVE.includes(conclusion) && !SUCCESSFUL.includes(conclusion)) {
+      count += 1;
+      continue;
+    }
+    break;
+  }
+  return count;
+}
+
+export function scoreCi(snapshot: RepositorySnapshot): CategoryScore {
+  const ci = snapshot.ci;
+  const repoUrl = snapshot.identity.htmlUrl;
+
+  const decisiveRuns = ci.recentRunConclusions.filter((c) => DECISIVE.includes(c));
+  const successCount = decisiveRuns.filter((c) => SUCCESSFUL.includes(c)).length;
+  const successRate =
+    decisiveRuns.length === 0 ? null : successCount / decisiveRuns.length;
+
+  const hasWorkflows = ci.workflowCount !== null && ci.workflowCount > 0;
+  const hasCommitStatus =
+    ci.latestCommitStatus !== null && ci.latestCommitStatus !== 'none';
+
+  // Nothing observable at all: no workflow information and no commit status.
+  // This is "we could not tell", which is not the same as "no CI".
+  if (ci.workflowCount === null && !hasCommitStatus) {
+    return {
+      key: 'ci',
+      label: CATEGORY_LABELS.ci,
+      score: null,
+      confidence: 'low',
+      metrics: [
+        metric('ci.workflows.count', 'Workflows', null, {
+          unknownReason: 'not_retrieved',
+        }),
+        metric('ci.runs.successRate', 'Recent run success rate', null, {
+          unknownReason: 'not_retrieved',
+        }),
+      ],
+      findings: [
+        {
+          id: 'ci.unavailable',
+          category: 'ci',
+          severity: 'info',
+          title: 'CI information could not be read',
+          explanation:
+            'RepoSignal could not read workflow or check information for this repository. This is an absence of data, not evidence that CI is missing or failing, so this category was excluded from the overall score.',
+          metric: { workflowCount: null },
+          recommendation: 'No action implied.',
+          confidence: 'high',
+          evidenceUrl: `${repoUrl}/actions`,
+        },
+      ],
+      explanation: {
+        summary: 'Not scored: CI information could not be read from public GitHub data.',
+        formula: 'Not applicable — excluded from the overall score.',
+        components: [],
+        limitations: [
+          'Workflow and check information was not retrievable. This category was excluded from the overall score rather than scored as zero, because unavailable data is not evidence of a failing or absent pipeline.',
+        ],
+      },
+    };
+  }
+
+  const findings: Finding[] = [];
+
+  // Readable, and there is genuinely no CI configured. That is a real
+  // observation, and it is scored on configuration — not on run outcomes.
+  if (ci.workflowCount === 0 && !hasCommitStatus) {
+    findings.push({
+      id: 'ci.notConfigured',
+      category: 'ci',
+      severity: 'medium',
+      title: 'No continuous integration configured',
+      explanation:
+        'No GitHub Actions workflows and no commit status checks were found. Changes are not verified automatically before they land, so regressions surface after merge rather than before.',
+      metric: { workflowCount: 0 },
+      recommendation:
+        'Add a workflow that runs the test suite and a build on every pull request.',
+      confidence: 'high',
+      evidenceUrl: `${repoUrl}/actions`,
+    });
+
+    const configurationComponent = component(
+      'ci.configured',
+      'CI configured',
+      0,
+      100,
+      'No workflows and no commit status checks',
+      'CI configured scores 100, none scores 0.',
+    );
+
+    return {
+      key: 'ci',
+      label: CATEGORY_LABELS.ci,
+      score: 0,
+      confidence: 'high',
+      metrics: [
+        metric('ci.workflows.count', 'Workflows', 0),
+        metric('ci.runs.successRate', 'Recent run success rate', null, {
+          unknownReason: 'not_applicable',
+        }),
+      ],
+      findings,
+      explanation: {
+        summary: 'No CI is configured on this repository.',
+        formula: describeFormula([configurationComponent]),
+        components: [configurationComponent],
+        limitations: [
+          'Only GitHub Actions workflows and commit status checks are visible. A project using external CI that does not report status back to GitHub would appear to have none.',
+        ],
+      },
+    };
+  }
+
+  const consecutiveFailures = countLeadingFailures(ci.recentRunConclusions);
+
+  const components = [
+    component(
+      'ci.configured',
+      'CI configured',
+      hasWorkflows || hasCommitStatus ? 100 : 0,
+      30,
+      hasWorkflows
+        ? `${ci.workflowCount} workflow${ci.workflowCount === 1 ? '' : 's'}`
+        : 'Commit status checks present',
+      'Workflows or commit status checks present scores 100.',
+    ),
+    component(
+      'ci.successRate',
+      'Recent run success rate',
+      successRate === null ? null : Math.round(successRate * 100),
+      45,
+      successRate === null
+        ? 'No decisive runs in the sample'
+        : `${successCount} of ${decisiveRuns.length} recent runs succeeded (${Math.round(successRate * 100)}%)`,
+      'Successful runs divided by decisive runs on the default branch. Cancelled and skipped runs are excluded rather than counted as failures.',
+    ),
+    component(
+      'ci.latestStatus',
+      'Latest commit status',
+      latestStatusScore(ci.latestCommitStatus),
+      25,
+      ci.latestCommitStatus === null || ci.latestCommitStatus === 'none'
+        ? 'No status on the latest default-branch commit'
+        : `Latest commit status: ${ci.latestCommitStatus}`,
+      'Success scores 100, pending scores 70, failure scores 0. No status is not scorable and its weight is redistributed.',
+    ),
+  ];
+
+  const { score, scoredWeight, totalWeight } = combine(components);
+
+  if (consecutiveFailures >= CONSECUTIVE_FAILURE_THRESHOLD) {
+    findings.push({
+      id: 'ci.consecutiveFailures',
+      category: 'ci',
+      severity: 'high',
+      title: 'Recent CI runs are failing consecutively',
+      explanation: `The ${consecutiveFailures} most recent decisive workflow runs on the default branch all failed. A persistently red default branch means CI has stopped functioning as a signal — contributors cannot tell whether their change broke something.`,
+      metric: {
+        consecutiveFailures,
+        threshold: CONSECUTIVE_FAILURE_THRESHOLD,
+      },
+      recommendation:
+        'Fix or quarantine the failing job so a red run means something again.',
+      confidence: 'high',
+      evidenceUrl: `${repoUrl}/actions`,
+    });
+  } else if (successRate !== null && successRate < 0.7 && decisiveRuns.length >= 10) {
+    findings.push({
+      id: 'ci.lowSuccessRate',
+      category: 'ci',
+      severity: 'medium',
+      title: 'CI fails often',
+      explanation: `${successCount} of the ${decisiveRuns.length} recent decisive runs on the default branch succeeded (${Math.round(successRate * 100)}%). Frequent failures on the default branch make it hard to tell a real regression from routine noise.`,
+      metric: {
+        successfulRuns: successCount,
+        decisiveRuns: decisiveRuns.length,
+        successRate: Number(successRate.toFixed(2)),
+      },
+      recommendation:
+        'Investigate whether failures are genuine regressions or flaky tests, and address the flakiness directly.',
+      confidence: ci.sample.truncated ? 'medium' : 'high',
+      evidenceUrl: `${repoUrl}/actions`,
+    });
+  }
+
+  const limitations = [
+    'Only GitHub Actions workflows and commit status checks are visible. A project using external CI that does not report status back to GitHub would appear to have none.',
+    'Cancelled and skipped runs are excluded from the success rate rather than counted as failures, since a cancelled run is usually a superseded one.',
+    'Run outcomes are read from the default branch only.',
+  ];
+
+  if (ci.sample.truncated) {
+    limitations.push(
+      'More workflow runs exist than were examined, so the success rate describes the sample rather than the full history.',
+    );
+  }
+
+  return {
+    key: 'ci',
+    label: CATEGORY_LABELS.ci,
+    score,
+    confidence: deriveConfidence({
+      scoredWeight,
+      totalWeight,
+      samples: [ci.sample],
+    }),
+    metrics: [
+      metric('ci.workflows.count', 'Workflows', ci.workflowCount, {
+        unknownReason: 'not_retrieved',
+      }),
+      metric('ci.runs.examined', 'Recent runs examined', ci.recentRunConclusions.length),
+      metric('ci.runs.decisive', 'Runs with a decisive outcome', decisiveRuns.length),
+      metric(
+        'ci.runs.successRate',
+        'Recent run success rate',
+        successRate === null ? null : Math.round(successRate * 100),
+        { unit: '%', unknownReason: 'insufficient_data' },
+      ),
+      metric(
+        'ci.runs.consecutiveFailures',
+        'Consecutive recent failures',
+        consecutiveFailures,
+      ),
+      metric('ci.latestCommitStatus', 'Latest commit status', ci.latestCommitStatus, {
+        unknownReason: 'not_retrieved',
+      }),
+    ],
+    findings,
+    explanation: {
+      summary:
+        'Measures whether automated checks exist and whether they are passing, using workflow runs on the default branch and the status of its most recent commit.',
+      formula: describeFormula(components),
+      components,
+      limitations,
+    },
+  };
+}
+
+function latestStatusScore(
+  status: RepositorySnapshot['ci']['latestCommitStatus'],
+): number | null {
+  switch (status) {
+    case 'success':
+      return 100;
+    case 'pending':
+      return 70;
+    case 'failure':
+      return 0;
+    case 'none':
+    case null:
+      // No status is not a failed status.
+      return null;
+    default:
+      return null;
+  }
+}

--- a/src/lib/scoring/documentation.ts
+++ b/src/lib/scoring/documentation.ts
@@ -1,0 +1,261 @@
+import type { CategoryScore, Finding } from '@/types/analysis';
+import type { FilePresence, RepositorySnapshot } from '@/types/snapshot';
+
+import {
+  combine,
+  component,
+  describeFormula,
+  deriveConfidence,
+  metric,
+} from './primitives';
+import { CATEGORY_LABELS } from './weights';
+
+/**
+ * Documentation scoring.
+ *
+ * Deliberately presence-based. RepoSignal does not judge the quality of prose —
+ * that would require reading and interpreting content, which is neither
+ * deterministic nor defensible. The one nuance is size: a 40-byte README that
+ * says only the project name is different from a substantial one, and file
+ * size distinguishes those without reading either.
+ */
+
+/**
+ * Below this, a README is a placeholder rather than documentation.
+ *
+ * 300 bytes is roughly a title, a one-line description, and an install
+ * command — enough to identify a project, not enough to explain it.
+ */
+export const README_STUB_BYTES = 300;
+
+/** A CONTRIBUTING file below this is a stub for the same reason. */
+export const CONTRIBUTING_STUB_BYTES = 200;
+
+function presenceScore(file: FilePresence): number {
+  return file.present ? 100 : 0;
+}
+
+/** Scores a file by presence, then by whether it is substantial. */
+function substanceScore(file: FilePresence, stubBytes: number): number {
+  if (!file.present) return 0;
+  if (file.sizeBytes === null) return 80; // present, size unknown
+  return file.sizeBytes >= stubBytes ? 100 : 50;
+}
+
+function describePresence(file: FilePresence, stubBytes?: number): string {
+  if (!file.present) return 'Absent';
+  if (file.sizeBytes === null) return `Present at ${file.path}`;
+  const stub =
+    stubBytes !== undefined && file.sizeBytes < stubBytes ? ', likely a stub' : '';
+  return `Present at ${file.path} (${file.sizeBytes} bytes${stub})`;
+}
+
+export function scoreDocumentation(snapshot: RepositorySnapshot): CategoryScore {
+  const files = snapshot.files;
+  const repoUrl = snapshot.identity.htmlUrl;
+
+  const components = [
+    component(
+      'documentation.readme',
+      'README',
+      substanceScore(files.readme, README_STUB_BYTES),
+      30,
+      describePresence(files.readme, README_STUB_BYTES),
+      `Present and ≥ ${README_STUB_BYTES} bytes scores 100; present but smaller scores 50; absent scores 0.`,
+    ),
+    component(
+      'documentation.license',
+      'LICENSE',
+      presenceScore(files.license),
+      20,
+      describePresence(files.license),
+      'Present scores 100, absent scores 0. Without one, the code is not legally reusable.',
+    ),
+    component(
+      'documentation.contributing',
+      'CONTRIBUTING',
+      substanceScore(files.contributing, CONTRIBUTING_STUB_BYTES),
+      15,
+      describePresence(files.contributing, CONTRIBUTING_STUB_BYTES),
+      `Present and ≥ ${CONTRIBUTING_STUB_BYTES} bytes scores 100; present but smaller scores 50; absent scores 0.`,
+    ),
+    component(
+      'documentation.codeOfConduct',
+      'Code of conduct',
+      presenceScore(files.codeOfConduct),
+      10,
+      describePresence(files.codeOfConduct),
+      'Present scores 100, absent scores 0.',
+    ),
+    component(
+      'documentation.issueTemplates',
+      'Issue templates',
+      presenceScore(files.issueTemplates),
+      10,
+      describePresence(files.issueTemplates),
+      'Present scores 100, absent scores 0.',
+    ),
+    component(
+      'documentation.pullRequestTemplate',
+      'Pull request template',
+      presenceScore(files.pullRequestTemplate),
+      5,
+      describePresence(files.pullRequestTemplate),
+      'Present scores 100, absent scores 0.',
+    ),
+    component(
+      'documentation.docsDirectory',
+      'Documentation directory',
+      presenceScore(files.docsDirectory),
+      10,
+      describePresence(files.docsDirectory),
+      'Present scores 100, absent scores 0. Extended documentation beyond the README.',
+    ),
+  ];
+
+  const { score, scoredWeight, totalWeight } = combine(components);
+  const findings: Finding[] = [];
+
+  if (!files.readme.present) {
+    findings.push({
+      id: 'documentation.readme.missing',
+      category: 'documentation',
+      severity: 'high',
+      title: 'No README',
+      explanation:
+        'The repository has no README at its root or in .github. A README is the first thing a visitor reads, and without one a project cannot explain what it does or how to use it.',
+      metric: { readmePresent: 'false' },
+      recommendation:
+        'Add a README covering what the project does, who it is for, and how to install and run it.',
+      confidence: 'high',
+      evidenceUrl: repoUrl,
+    });
+  } else if (
+    files.readme.sizeBytes !== null &&
+    files.readme.sizeBytes < README_STUB_BYTES
+  ) {
+    findings.push({
+      id: 'documentation.readme.stub',
+      category: 'documentation',
+      severity: 'medium',
+      title: 'README is very short',
+      explanation: `The README is ${files.readme.sizeBytes} bytes, below the ${README_STUB_BYTES}-byte threshold RepoSignal uses to distinguish a placeholder from documentation. This measures length only, not quality.`,
+      metric: {
+        readmeBytes: files.readme.sizeBytes,
+        thresholdBytes: README_STUB_BYTES,
+      },
+      recommendation:
+        'Expand the README to cover purpose, installation, and basic usage.',
+      confidence: 'high',
+      ...(files.readme.htmlUrl === null ? {} : { evidenceUrl: files.readme.htmlUrl }),
+    });
+  }
+
+  if (!files.license.present) {
+    findings.push({
+      id: 'documentation.license.missing',
+      category: 'documentation',
+      severity: 'high',
+      title: 'No LICENSE file',
+      explanation:
+        'No license file was found. Without an explicit license, default copyright applies and others have no legal right to use, modify, or distribute the code — regardless of it being publicly visible.',
+      metric: { licensePresent: 'false' },
+      recommendation:
+        'Add a LICENSE file. https://choosealicense.com walks through the options.',
+      confidence: 'high',
+      evidenceUrl: repoUrl,
+    });
+  }
+
+  if (!files.contributing.present) {
+    findings.push({
+      id: 'documentation.contributing.missing',
+      category: 'documentation',
+      severity: 'low',
+      title: 'No contributing guide',
+      explanation:
+        'No CONTRIBUTING file was found. Contributors have to infer the workflow, branch conventions, and testing expectations from the commit history.',
+      metric: { contributingPresent: 'false' },
+      recommendation:
+        'Add CONTRIBUTING.md describing how to set up the project, run tests, and open a pull request.',
+      confidence: 'high',
+      evidenceUrl: repoUrl,
+    });
+  }
+
+  if (!files.issueTemplates.present && !files.pullRequestTemplate.present) {
+    findings.push({
+      id: 'documentation.templates.missing',
+      category: 'documentation',
+      severity: 'low',
+      title: 'No issue or pull request templates',
+      explanation:
+        'Neither issue templates nor a pull request template were found in .github. Templates make reports and contributions arrive with the context needed to act on them.',
+      metric: { issueTemplates: 'false', pullRequestTemplate: 'false' },
+      recommendation:
+        'Add templates under .github/ISSUE_TEMPLATE and .github/pull_request_template.md.',
+      confidence: 'high',
+      evidenceUrl: repoUrl,
+    });
+  }
+
+  return {
+    key: 'documentation',
+    label: CATEGORY_LABELS.documentation,
+    score,
+    confidence: deriveConfidence({ scoredWeight, totalWeight }),
+    metrics: [
+      metric(
+        'documentation.readme.present',
+        'README present',
+        String(files.readme.present),
+      ),
+      metric('documentation.readme.bytes', 'README size', files.readme.sizeBytes, {
+        unit: 'bytes',
+        unknownReason: 'not_retrieved',
+      }),
+      metric(
+        'documentation.license.present',
+        'LICENSE present',
+        String(files.license.present),
+      ),
+      metric(
+        'documentation.contributing.present',
+        'CONTRIBUTING present',
+        String(files.contributing.present),
+      ),
+      metric(
+        'documentation.codeOfConduct.present',
+        'Code of conduct present',
+        String(files.codeOfConduct.present),
+      ),
+      metric(
+        'documentation.issueTemplates.present',
+        'Issue templates present',
+        String(files.issueTemplates.present),
+      ),
+      metric(
+        'documentation.pullRequestTemplate.present',
+        'Pull request template present',
+        String(files.pullRequestTemplate.present),
+      ),
+      metric(
+        'documentation.docsDirectory.present',
+        'Documentation directory present',
+        String(files.docsDirectory.present),
+      ),
+    ],
+    findings,
+    explanation: {
+      summary:
+        'Measures whether the files a newcomer needs are present, and whether the README and contributing guide are substantial enough to be useful.',
+      formula: describeFormula(components),
+      components,
+      limitations: [
+        'Presence and size only. RepoSignal does not read documentation content, so it cannot tell a thorough README from a long but unhelpful one.',
+        'Only the repository root and .github are examined. Documentation kept elsewhere, or in an external site not linked from a docs directory, is not detected.',
+        'Files are matched by conventional name. A README under an unconventional filename will be reported as absent.',
+      ],
+    },
+  };
+}

--- a/src/lib/scoring/index.ts
+++ b/src/lib/scoring/index.ts
@@ -1,0 +1,88 @@
+import type { AnalysisResult, CategoryScore, Finding, Severity } from '@/types/analysis';
+import type { RepositorySnapshot } from '@/types/snapshot';
+
+import { scoreActivity } from './activity';
+import { scoreCi } from './ci';
+import { scoreDocumentation } from './documentation';
+import { scoreIssues } from './issues';
+import { scoreOverall } from './overall';
+import { scorePullRequests } from './pull-requests';
+import { scoreRepository } from './repository';
+import { scoreSecurity } from './security';
+import { SCORING_VERSION } from './weights';
+
+export { SCORING_VERSION } from './weights';
+
+const SEVERITY_ORDER: Record<Severity, number> = {
+  high: 0,
+  medium: 1,
+  low: 2,
+  info: 3,
+};
+
+/**
+ * Runs every category scorer over a snapshot and combines the results.
+ *
+ * Pure: given the same snapshot, `now`, and `analysisId`, this returns the same
+ * result forever. That is what makes the scoring engine testable without a
+ * network and what lets a stored analysis stay interpretable.
+ */
+export function analyzeSnapshot(
+  snapshot: RepositorySnapshot,
+  options: { now: Date; analysisId: string },
+): AnalysisResult {
+  const categories: CategoryScore[] = [
+    scoreActivity(snapshot, options.now),
+    scorePullRequests(snapshot),
+    scoreIssues(snapshot),
+    scoreCi(snapshot),
+    scoreDocumentation(snapshot),
+    scoreRepository(snapshot),
+    scoreSecurity(snapshot),
+  ];
+
+  const overall = scoreOverall(categories);
+
+  const findings = categories
+    .flatMap((category) => category.findings)
+    .sort((a, b) => {
+      const bySeverity = SEVERITY_ORDER[a.severity] - SEVERITY_ORDER[b.severity];
+      return bySeverity !== 0 ? bySeverity : a.category.localeCompare(b.category);
+    });
+
+  const limitations: string[] = [];
+
+  for (const failure of snapshot.collection.failures) {
+    limitations.push(
+      `Could not retrieve ${failure.resource} from GitHub (${failure.reason}). Anything derived from it was excluded rather than assumed.`,
+    );
+  }
+
+  if (snapshot.identity.isFork) {
+    limitations.push(
+      'This repository is a fork. Activity and contribution signals may reflect the upstream project rather than work done here.',
+    );
+  }
+
+  return {
+    scoringVersion: SCORING_VERSION,
+    analysisId: options.analysisId,
+    analyzedAt: snapshot.capturedAt,
+    repository: snapshot.identity,
+    overall,
+    categories,
+    findings,
+    limitations,
+  };
+}
+
+export {
+  scoreActivity,
+  scoreCi,
+  scoreDocumentation,
+  scoreIssues,
+  scoreOverall,
+  scorePullRequests,
+  scoreRepository,
+  scoreSecurity,
+};

--- a/src/lib/scoring/index.ts
+++ b/src/lib/scoring/index.ts
@@ -1,4 +1,4 @@
-import type { AnalysisResult, CategoryScore, Finding, Severity } from '@/types/analysis';
+import type { AnalysisResult, CategoryScore, Severity } from '@/types/analysis';
 import type { RepositorySnapshot } from '@/types/snapshot';
 
 import { scoreActivity } from './activity';

--- a/src/lib/scoring/issues.ts
+++ b/src/lib/scoring/issues.ts
@@ -1,0 +1,259 @@
+import { median, proportionAtLeast } from '@/lib/normalize/dates';
+import type { CategoryScore, Finding } from '@/types/analysis';
+import type { RepositorySnapshot } from '@/types/snapshot';
+
+import {
+  combine,
+  component,
+  describeFormula,
+  deriveConfidence,
+  metric,
+  scoreDescending,
+} from './primitives';
+import { CATEGORY_LABELS } from './weights';
+
+/**
+ * Issue health scoring.
+ *
+ * Every statement this module makes is an observation. "37 issues have had no
+ * activity for more than 180 days" is a fact about the data. "The maintainers
+ * are ignoring the backlog" is a claim about intent, which RepoSignal cannot
+ * observe and will not make. A large stale backlog on a finished, stable
+ * library means something quite different than on an actively marketed one,
+ * and RepoSignal cannot tell those apart.
+ */
+
+/**
+ * An issue with no activity beyond this is stale.
+ *
+ * 180 days is chosen because it survives a normal release cycle and a quiet
+ * summer. Shorter thresholds flag healthy projects that batch triage; longer
+ * ones stop distinguishing anything.
+ */
+export const STALE_ISSUE_DAYS = 180;
+
+/** Bands for the proportion of open issues that are stale. Lower is better. */
+const STALE_RATIO_BANDS = [
+  { upTo: 0.1, score: 100, label: 'Under 10% stale' },
+  { upTo: 0.25, score: 85, label: 'Under 25% stale' },
+  { upTo: 0.5, score: 60, label: 'Under 50% stale' },
+  { upTo: 0.75, score: 35, label: 'Under 75% stale' },
+  { upTo: Infinity, score: 15, label: '75% or more stale' },
+];
+
+/** Bands for median open-issue age in days. Lower is better. */
+const MEDIAN_AGE_BANDS = [
+  { upTo: 30, score: 100, label: 'Median under 30 days' },
+  { upTo: 90, score: 85, label: 'Median under 90 days' },
+  { upTo: 180, score: 65, label: 'Median under 180 days' },
+  { upTo: 365, score: 45, label: 'Median under a year' },
+  { upTo: Infinity, score: 25, label: 'Median over a year' },
+];
+
+export function scoreIssues(snapshot: RepositorySnapshot): CategoryScore {
+  const issues = snapshot.issues;
+  const repoUrl = snapshot.identity.htmlUrl;
+
+  // Issues disabled is "not applicable", not "a perfect backlog" and not
+  // "zero". The category scores null and its weight is redistributed.
+  if (issues === null) {
+    return {
+      key: 'issues',
+      label: CATEGORY_LABELS.issues,
+      score: null,
+      confidence: 'high',
+      metrics: [
+        metric('issues.enabled', 'Issues enabled', 'false'),
+        metric('issues.open.count', 'Open issues', null, {
+          unknownReason: 'not_applicable',
+        }),
+      ],
+      findings: [
+        {
+          id: 'issues.disabled',
+          category: 'issues',
+          severity: 'info',
+          title: 'Issues are disabled',
+          explanation:
+            'This repository has GitHub Issues turned off, so there is no issue backlog to assess. Many projects track work elsewhere; this is not itself a problem.',
+          metric: { issuesEnabled: 'false' },
+          recommendation:
+            'No action implied. If the project tracks issues elsewhere, linking to that from the README helps visitors.',
+          confidence: 'high',
+          evidenceUrl: repoUrl,
+        },
+      ],
+      explanation: {
+        summary: 'Not scored: this repository has issues disabled.',
+        formula: 'Not applicable — excluded from the overall score.',
+        components: [],
+        limitations: [
+          'Issues are disabled on this repository, so issue health could not be assessed. This category was excluded from the overall score rather than scored as zero.',
+        ],
+      },
+    };
+  }
+
+  const staleCount = issues.openInactiveDays.filter(
+    (days) => days >= STALE_ISSUE_DAYS,
+  ).length;
+  const staleRatio = proportionAtLeast(issues.openInactiveDays, STALE_ISSUE_DAYS);
+  const medianAge = median(issues.openAgeDays);
+
+  const stale = scoreDescending(staleRatio, STALE_RATIO_BANDS);
+  const age = scoreDescending(medianAge, MEDIAN_AGE_BANDS);
+
+  // Closing at least as many issues as are opened means the backlog is not
+  // growing. Above 1.0 it is shrinking, which is capped at 100.
+  const closeRatio =
+    issues.createdLast90Days === 0
+      ? issues.closedLast90Days > 0
+        ? 1
+        : null
+      : issues.closedLast90Days / issues.createdLast90Days;
+
+  const responsiveness =
+    closeRatio === null ? null : Math.round(Math.min(1, closeRatio) * 100);
+
+  const components = [
+    component(
+      'issues.staleRatio',
+      'Stale issue proportion',
+      stale.score,
+      40,
+      staleRatio === null
+        ? 'No open issues to assess'
+        : `${staleCount} of ${issues.openInactiveDays.length} open issues inactive for ${STALE_ISSUE_DAYS}+ days (${Math.round(staleRatio * 100)}%)`,
+      `Proportion of open issues with no activity for ${STALE_ISSUE_DAYS}+ days. ${stale.label}.`,
+    ),
+    component(
+      'issues.medianAge',
+      'Median open issue age',
+      age.score,
+      30,
+      medianAge === null ? 'No open issues to assess' : `${medianAge} days`,
+      `Median age of open issues. ${age.label}.`,
+    ),
+    component(
+      'issues.responsiveness',
+      'Close rate against open rate',
+      responsiveness,
+      30,
+      closeRatio === null
+        ? 'No issue activity in the last 90 days'
+        : `${issues.closedLast90Days} closed against ${issues.createdLast90Days} opened in 90 days`,
+      'Issues closed divided by issues opened over the trailing 90 days, capped at 1.0. A ratio at or above 1.0 means the backlog is not growing.',
+    ),
+  ];
+
+  const { score, scoredWeight, totalWeight } = combine(components);
+  const findings: Finding[] = [];
+
+  const staleQuery = `${repoUrl}/issues?q=${encodeURIComponent(
+    `is:issue is:open updated:<${isoDaysBefore(snapshot.capturedAt, STALE_ISSUE_DAYS)}`,
+  )}`;
+
+  if (staleCount > 0 && staleRatio !== null && staleRatio >= 0.25) {
+    findings.push({
+      id: 'issues.stale.backlog',
+      category: 'issues',
+      severity: staleRatio >= 0.5 ? 'high' : 'medium',
+      title: 'Large proportion of stale issues',
+      explanation: `${staleCount} of the ${issues.openInactiveDays.length} open issues examined have had no activity for more than ${STALE_ISSUE_DAYS} days. A large stale queue makes prioritization harder and can make a project look unmaintained to a newcomer, whatever the reality.`,
+      metric: {
+        staleIssues: staleCount,
+        openIssuesExamined: issues.openInactiveDays.length,
+        thresholdDays: STALE_ISSUE_DAYS,
+        stalePercentage: Math.round(staleRatio * 100),
+      },
+      recommendation:
+        'Review stale issues and classify them — still relevant, needs information, or out of scope. Closing in bulk without reading loses real reports.',
+      confidence: issues.sample.truncated ? 'medium' : 'high',
+      evidenceUrl: staleQuery,
+    });
+  }
+
+  if (closeRatio !== null && closeRatio < 0.5 && issues.createdLast90Days >= 10) {
+    findings.push({
+      id: 'issues.backlog.growing',
+      category: 'issues',
+      severity: 'medium',
+      title: 'Issue backlog is growing',
+      explanation: `Over the last 90 days, ${issues.createdLast90Days} issues were opened and ${issues.closedLast90Days} were closed. At this rate the backlog grows faster than it is resolved.`,
+      metric: {
+        openedLast90Days: issues.createdLast90Days,
+        closedLast90Days: issues.closedLast90Days,
+        ratio: Number(closeRatio.toFixed(2)),
+      },
+      recommendation:
+        'Consider whether triage capacity matches inbound volume — through templates that reduce back-and-forth, or more contributors with triage rights.',
+      confidence: issues.sample.truncated ? 'medium' : 'high',
+      evidenceUrl: `${repoUrl}/issues`,
+    });
+  }
+
+  if (issues.openCount === 0) {
+    findings.push({
+      id: 'issues.backlog.empty',
+      category: 'issues',
+      severity: 'info',
+      title: 'No open issues',
+      explanation:
+        'The repository has no open issues. That can mean a well-maintained backlog, or that users report problems elsewhere.',
+      metric: { openIssues: 0 },
+      recommendation: 'No action implied.',
+      confidence: 'high',
+      evidenceUrl: `${repoUrl}/issues`,
+    });
+  }
+
+  return {
+    key: 'issues',
+    label: CATEGORY_LABELS.issues,
+    score,
+    confidence: deriveConfidence({
+      scoredWeight,
+      totalWeight,
+      samples: [issues.sample],
+    }),
+    metrics: [
+      metric('issues.open.count', 'Open issues examined', issues.openCount),
+      metric('issues.stale.count', 'Stale issues', staleCount),
+      metric('issues.stale.thresholdDays', 'Stale threshold', STALE_ISSUE_DAYS, {
+        unit: 'days',
+      }),
+      metric('issues.medianAge', 'Median open issue age', medianAge, {
+        unit: 'days',
+        unknownReason: 'insufficient_data',
+      }),
+      metric('issues.opened90d', 'Opened in last 90 days', issues.createdLast90Days),
+      metric('issues.closed90d', 'Closed in last 90 days', issues.closedLast90Days),
+      metric('issues.sample.examined', 'Issues examined', issues.sample.examined),
+      metric(
+        'issues.sample.truncated',
+        'Sample truncated',
+        String(issues.sample.truncated),
+      ),
+    ],
+    findings,
+    explanation: {
+      summary:
+        'Measures whether the issue backlog is being tended: how much of it is stale, how old it is, and whether issues are closed as fast as they arrive.',
+      formula: describeFormula(components),
+      components,
+      limitations: [
+        `Based on a sample of up to 300 issues${issues.sample.truncated ? ', which was truncated for this repository' : ''}. Counts describe what was examined, not necessarily the full backlog.`,
+        'Pull requests are excluded, since GitHub returns them from the same endpoint.',
+        'RepoSignal reports observed activity only. It cannot tell a neglected issue from one deliberately left open as a known limitation.',
+        'A stale backlog on a stable, finished project means something different than on an actively developed one. This distinction is not observable from the data.',
+      ],
+    },
+  };
+}
+
+/** ISO date `days` before a reference timestamp, for a GitHub search query. */
+function isoDaysBefore(reference: string, days: number): string {
+  const date = new Date(reference);
+  date.setUTCDate(date.getUTCDate() - days);
+  return date.toISOString().slice(0, 10);
+}

--- a/src/lib/scoring/overall.ts
+++ b/src/lib/scoring/overall.ts
@@ -1,0 +1,128 @@
+import type { CategoryScore, Confidence, OverallScore } from '@/types/analysis';
+
+import { CATEGORY_WEIGHTS, MINIMUM_SCORED_CATEGORIES } from './weights';
+
+/**
+ * Combines category scores into one number.
+ *
+ * This is the most important twelve lines in the project, because it is where
+ * the null-preservation rule either holds or quietly breaks.
+ *
+ * A category that returned `null` is **excluded**, and its declared weight is
+ * redistributed proportionally across the categories that did produce a score.
+ * The consequence, asserted directly by a regression test: adding a null
+ * category can never lower the overall score.
+ *
+ * If missing categories were instead scored as zero, a repository with issues
+ * disabled would be punished for a setting, and one whose commit statistics
+ * GitHub had not computed would be punished for GitHub's queue.
+ */
+export function scoreOverall(categories: CategoryScore[]): OverallScore {
+  const scored = categories.filter(
+    (category): category is CategoryScore & { score: number } => category.score !== null,
+  );
+
+  const excluded = categories
+    .filter((category) => category.score === null)
+    .map((category) => ({
+      key: category.key,
+      reason: excludedReason(category),
+    }));
+
+  // Below the minimum, an average would imply far more coverage than the
+  // evidence supports, so no number is reported at all.
+  if (scored.length < MINIMUM_SCORED_CATEGORIES) {
+    return {
+      score: null,
+      confidence: 'low',
+      contributions: [],
+      excluded,
+      formula: `Not scored: ${scored.length} of ${categories.length} categories produced a score, below the minimum of ${MINIMUM_SCORED_CATEGORIES} required to report an overall number.`,
+    };
+  }
+
+  const scoredWeight = scored.reduce(
+    (sum, category) => sum + CATEGORY_WEIGHTS[category.key],
+    0,
+  );
+
+  const contributions = scored.map((category) => {
+    const declaredWeight = CATEGORY_WEIGHTS[category.key];
+    return {
+      key: category.key,
+      score: category.score,
+      declaredWeight,
+      // Renormalized so the effective weights sum to 100 across whatever was
+      // actually scorable.
+      effectiveWeight: Number(((declaredWeight / scoredWeight) * 100).toFixed(1)),
+    };
+  });
+
+  const weighted = scored.reduce(
+    (sum, category) => sum + category.score * CATEGORY_WEIGHTS[category.key],
+    0,
+  );
+
+  const terms = contributions
+    .map((c) => `${c.score} × ${(c.effectiveWeight / 100).toFixed(3)}`)
+    .join(' + ');
+
+  const note =
+    excluded.length === 0
+      ? ''
+      : ` ${excluded.length} categor${excluded.length === 1 ? 'y' : 'ies'} could not be scored and ${excluded.length === 1 ? 'its weight was' : 'their weights were'} redistributed across the rest, never counted as zero.`;
+
+  return {
+    score: Math.round(weighted / scoredWeight),
+    confidence: deriveOverallConfidence(scored, scoredWeight),
+    contributions,
+    excluded,
+    formula: `${terms}.${note}`,
+  };
+}
+
+/**
+ * Overall confidence, from two independent inputs: how much of the declared
+ * weight was scorable, and how confident the scored categories themselves are.
+ * The lower of the two governs — a total built from confident categories that
+ * only cover half the picture is not a confident total.
+ */
+function deriveOverallConfidence(
+  scored: CategoryScore[],
+  scoredWeight: number,
+): Confidence {
+  const totalWeight = Object.values(CATEGORY_WEIGHTS).reduce((sum, w) => sum + w, 0);
+  const coverage = scoredWeight / totalWeight;
+
+  const rank: Record<Confidence, number> = { low: 0, medium: 1, high: 2 };
+  const worstCategory = scored.reduce<Confidence>(
+    (worst, category) =>
+      rank[category.confidence] < rank[worst] ? category.confidence : worst,
+    'high',
+  );
+
+  const coverageConfidence: Confidence =
+    coverage >= 0.85 ? 'high' : coverage >= 0.6 ? 'medium' : 'low';
+
+  return rank[coverageConfidence] < rank[worstCategory]
+    ? coverageConfidence
+    : worstCategory;
+}
+
+/** Human-readable reason a category was excluded, taken from its explanation. */
+function excludedReason(category: CategoryScore): string {
+  return (
+    category.explanation.limitations[0] ??
+    'This category could not be scored from the available data.'
+  );
+}
+
+/**
+ * Asserts the declared weights sum to 100.
+ *
+ * Called by a test rather than at runtime — a weight table that does not sum
+ * to 100 is a bug to catch in CI, not a condition to handle in production.
+ */
+export function totalDeclaredWeight(): number {
+  return Object.values(CATEGORY_WEIGHTS).reduce((sum, weight) => sum + weight, 0);
+}

--- a/src/lib/scoring/primitives.ts
+++ b/src/lib/scoring/primitives.ts
@@ -1,0 +1,179 @@
+import type { Confidence, Metric, ScoreComponent, UnknownReason } from '@/types/analysis';
+import type { SampleReport } from '@/types/snapshot';
+
+/**
+ * Shared building blocks for the scoring modules.
+ *
+ * The important one is `combine`, which implements the null-preservation rule
+ * every category depends on: a component that could not be evaluated is
+ * dropped and its weight is redistributed, rather than being scored as zero.
+ */
+
+/** A threshold band: values at or below `upTo` score `score`. */
+export interface Band {
+  upTo: number;
+  score: number;
+  label: string;
+}
+
+/**
+ * Scores a value against ordered bands, ascending by `upTo`.
+ *
+ * Lower is better — used for ages, staleness, and days since an event. The
+ * final band should use `Infinity` so every value is covered.
+ */
+export function scoreDescending(
+  value: number | null,
+  bands: Band[],
+): { score: number | null; label: string } {
+  if (value === null) return { score: null, label: 'Unknown' };
+
+  for (const band of bands) {
+    if (value <= band.upTo) return { score: band.score, label: band.label };
+  }
+
+  const last = bands[bands.length - 1];
+  return { score: last?.score ?? 0, label: last?.label ?? 'Unknown' };
+}
+
+/**
+ * Scores a value against ordered bands where higher is better.
+ *
+ * Bands are given descending by `atLeast`.
+ */
+export function scoreAscending(
+  value: number | null,
+  bands: Array<{ atLeast: number; score: number; label: string }>,
+): { score: number | null; label: string } {
+  if (value === null) return { score: null, label: 'Unknown' };
+
+  for (const band of bands) {
+    if (value >= band.atLeast) return { score: band.score, label: band.label };
+  }
+
+  const last = bands[bands.length - 1];
+  return { score: last?.score ?? 0, label: last?.label ?? 'Unknown' };
+}
+
+/**
+ * Combines weighted components into a category score.
+ *
+ * **This is where the null-preservation rule lives.** Components that could
+ * not be evaluated are excluded and their weight is redistributed across the
+ * remainder, so a repository is never penalized for data RepoSignal could not
+ * observe. Scoring an unobservable component as zero is the single easiest way
+ * to make the whole product dishonest.
+ *
+ * Returns `null` when nothing was scorable, or when the scorable components
+ * carry less than `minimumWeightRatio` of the declared weight — a score built
+ * from a fifth of its intended evidence is not worth presenting as a number.
+ */
+export function combine(
+  components: ScoreComponent[],
+  options: { minimumWeightRatio?: number } = {},
+): { score: number | null; scoredWeight: number; totalWeight: number } {
+  const minimumRatio = options.minimumWeightRatio ?? 0.5;
+
+  const totalWeight = components.reduce((sum, c) => sum + c.weight, 0);
+  const scored = components.filter(
+    (component): component is ScoreComponent & { score: number } =>
+      component.score !== null,
+  );
+  const scoredWeight = scored.reduce((sum, c) => sum + c.weight, 0);
+
+  if (scoredWeight === 0 || totalWeight === 0) {
+    return { score: null, scoredWeight, totalWeight };
+  }
+
+  if (scoredWeight / totalWeight < minimumRatio) {
+    return { score: null, scoredWeight, totalWeight };
+  }
+
+  // Renormalize over the scored components only.
+  const weighted = scored.reduce((sum, c) => sum + c.score * c.weight, 0);
+  return {
+    score: Math.round(weighted / scoredWeight),
+    scoredWeight,
+    totalWeight,
+  };
+}
+
+/**
+ * Confidence for a category.
+ *
+ * Two things lower it, and they are independent: how much of the intended
+ * evidence was observable at all, and whether what was observed came from a
+ * truncated sample. A finding derived from a partial view is `medium` at best,
+ * however complete the rest of the category is.
+ */
+export function deriveConfidence(input: {
+  scoredWeight: number;
+  totalWeight: number;
+  samples?: Array<SampleReport | null | undefined>;
+}): Confidence {
+  const ratio = input.totalWeight === 0 ? 0 : input.scoredWeight / input.totalWeight;
+  const truncated = (input.samples ?? []).some((sample) => sample?.truncated === true);
+
+  if (ratio >= 0.9 && !truncated) return 'high';
+  if (ratio >= 0.6) return truncated ? 'medium' : 'high';
+  if (ratio >= 0.4) return 'medium';
+  return 'low';
+}
+
+/** Builds an observed metric. */
+export function metric(
+  id: string,
+  label: string,
+  value: number | string | null,
+  options: { unit?: string; unknownReason?: UnknownReason; source?: string } = {},
+): Metric {
+  return {
+    id,
+    label,
+    value,
+    ...(options.unit === undefined ? {} : { unit: options.unit }),
+    ...(value === null && options.unknownReason !== undefined
+      ? { unknownReason: options.unknownReason }
+      : {}),
+    ...(options.source === undefined ? {} : { source: options.source }),
+  };
+}
+
+/** Builds a weighted score component. */
+export function component(
+  id: string,
+  label: string,
+  score: number | null,
+  weight: number,
+  observed: string,
+  rule: string,
+): ScoreComponent {
+  return { id, label, score, weight, observed, rule };
+}
+
+/**
+ * Renders the arithmetic behind a category score as a readable string.
+ *
+ * This is shown verbatim in the UI's methodology disclosure, which is the
+ * point: a user who disagrees with a score can see exactly which term produced
+ * it rather than being asked to trust the total.
+ */
+export function describeFormula(components: ScoreComponent[]): string {
+  const scored = components.filter((c) => c.score !== null);
+  if (scored.length === 0) return 'No component could be evaluated.';
+
+  const scoredWeight = scored.reduce((sum, c) => sum + c.weight, 0);
+  const terms = scored
+    .map((c) => `${c.score} × ${(c.weight / scoredWeight).toFixed(2)}`)
+    .join(' + ');
+
+  const excluded = components.filter((c) => c.score === null);
+  const note =
+    excluded.length === 0
+      ? ''
+      : ` Excluded as unobservable, with weight redistributed: ${excluded
+          .map((c) => c.label)
+          .join(', ')}.`;
+
+  return `${terms}${note}`;
+}

--- a/src/lib/scoring/pull-requests.ts
+++ b/src/lib/scoring/pull-requests.ts
@@ -1,0 +1,261 @@
+import { median, proportionAtLeast } from '@/lib/normalize/dates';
+import type { CategoryScore, Finding } from '@/types/analysis';
+import type { RepositorySnapshot } from '@/types/snapshot';
+
+import {
+  combine,
+  component,
+  describeFormula,
+  deriveConfidence,
+  metric,
+  scoreDescending,
+} from './primitives';
+import { CATEGORY_LABELS } from './weights';
+
+/**
+ * Pull request health scoring.
+ *
+ * Everything here is derived from a bounded sample of recent pull requests, so
+ * every derived metric is approximate and is labelled as such in the UI. The
+ * alternative — enumerating every PR on a large repository — would cost
+ * hundreds of requests for precision that does not change any conclusion.
+ *
+ * Merge duration uses the median rather than the mean, because one PR left
+ * open for four years and then merged would otherwise make a fast-merging
+ * project look slow.
+ */
+
+/** An open PR older than this is long-lived. */
+export const LONG_LIVED_PR_DAYS = 90;
+
+/** Bands for the proportion of open PRs that are long-lived. Lower is better. */
+const LONG_LIVED_RATIO_BANDS = [
+  { upTo: 0.1, score: 100, label: 'Under 10% long-lived' },
+  { upTo: 0.25, score: 85, label: 'Under 25% long-lived' },
+  { upTo: 0.5, score: 60, label: 'Under 50% long-lived' },
+  { upTo: 0.75, score: 35, label: 'Under 75% long-lived' },
+  { upTo: Infinity, score: 15, label: '75% or more long-lived' },
+];
+
+/** Bands for median days from opening to merge. Lower is better. */
+const MERGE_DURATION_BANDS = [
+  { upTo: 2, score: 100, label: 'Median under 2 days' },
+  { upTo: 7, score: 90, label: 'Median under a week' },
+  { upTo: 30, score: 70, label: 'Median under a month' },
+  { upTo: 90, score: 45, label: 'Median under 3 months' },
+  { upTo: Infinity, score: 25, label: 'Median over 3 months' },
+];
+
+export function scorePullRequests(snapshot: RepositorySnapshot): CategoryScore {
+  const prs = snapshot.pullRequests;
+  const repoUrl = snapshot.identity.htmlUrl;
+
+  // Never having had a pull request is not the same as never merging one.
+  if (prs === null) {
+    return {
+      key: 'pullRequests',
+      label: CATEGORY_LABELS.pullRequests,
+      score: null,
+      confidence: 'high',
+      metrics: [
+        metric('pullRequests.total', 'Pull requests examined', 0),
+        metric('pullRequests.open.count', 'Open pull requests', null, {
+          unknownReason: 'insufficient_data',
+        }),
+      ],
+      findings: [
+        {
+          id: 'pullRequests.none',
+          category: 'pullRequests',
+          severity: 'info',
+          title: 'No pull requests found',
+          explanation:
+            'RepoSignal found no pull requests on this repository. That is normal for a project developed by pushing directly to a branch, and says nothing about how changes are reviewed.',
+          metric: { pullRequestsExamined: 0 },
+          recommendation: 'No action implied.',
+          confidence: 'high',
+          evidenceUrl: `${repoUrl}/pulls`,
+        },
+      ],
+      explanation: {
+        summary: 'Not scored: no pull requests were found.',
+        formula: 'Not applicable — excluded from the overall score.',
+        components: [],
+        limitations: [
+          'No pull requests were found, so pull request health could not be assessed. This category was excluded from the overall score rather than scored as zero.',
+        ],
+      },
+    };
+  }
+
+  const longLivedCount = prs.openAgeDays.filter(
+    (days) => days >= LONG_LIVED_PR_DAYS,
+  ).length;
+  const longLivedRatio = proportionAtLeast(prs.openAgeDays, LONG_LIVED_PR_DAYS);
+  const medianMergeDays = median(prs.mergedDurationDays);
+
+  const longLived = scoreDescending(longLivedRatio, LONG_LIVED_RATIO_BANDS);
+  const mergeSpeed = scoreDescending(medianMergeDays, MERGE_DURATION_BANDS);
+
+  const decided = prs.recentlyMergedCount + prs.recentlyClosedUnmergedCount;
+  const mergeRate = decided === 0 ? null : prs.recentlyMergedCount / decided;
+  const mergeRateScore = mergeRate === null ? null : Math.round(mergeRate * 100);
+
+  const components = [
+    component(
+      'pullRequests.longLivedRatio',
+      'Long-lived open pull requests',
+      longLived.score,
+      35,
+      longLivedRatio === null
+        ? 'No open pull requests to assess'
+        : `${longLivedCount} of ${prs.openAgeDays.length} open PRs older than ${LONG_LIVED_PR_DAYS} days (${Math.round(longLivedRatio * 100)}%)`,
+      `Proportion of open pull requests older than ${LONG_LIVED_PR_DAYS} days. ${longLived.label}.`,
+    ),
+    component(
+      'pullRequests.mergeDuration',
+      'Median time to merge (approximate)',
+      mergeSpeed.score,
+      35,
+      medianMergeDays === null
+        ? 'No merged pull requests in the sample'
+        : `${medianMergeDays} days (median of ${prs.mergedDurationDays.length} merged PRs sampled)`,
+      `Median days from opening to merge across the sample. ${mergeSpeed.label}. Median is used so a single very old merge cannot distort the result.`,
+    ),
+    component(
+      'pullRequests.mergeRate',
+      'Merged share of decided pull requests',
+      mergeRateScore,
+      30,
+      decided === 0
+        ? 'No pull requests were decided in the last 90 days'
+        : `${prs.recentlyMergedCount} merged, ${prs.recentlyClosedUnmergedCount} closed unmerged, in the last 90 days`,
+      'Merged divided by merged-plus-closed-unmerged over the trailing 90 days.',
+    ),
+  ];
+
+  const { score, scoredWeight, totalWeight } = combine(components);
+  const findings: Finding[] = [];
+
+  if (longLivedRatio !== null && longLivedRatio >= 0.25 && longLivedCount > 0) {
+    findings.push({
+      id: 'pullRequests.longLived',
+      category: 'pullRequests',
+      severity: longLivedRatio >= 0.5 ? 'high' : 'medium',
+      title: 'Many long-lived open pull requests',
+      explanation: `${longLivedCount} of the ${prs.openAgeDays.length} open pull requests examined have been open for more than ${LONG_LIVED_PR_DAYS} days. Long-lived branches drift from the default branch and become progressively harder to merge.`,
+      metric: {
+        longLivedPullRequests: longLivedCount,
+        openPullRequestsExamined: prs.openAgeDays.length,
+        thresholdDays: LONG_LIVED_PR_DAYS,
+      },
+      recommendation:
+        'Review the oldest open pull requests and either progress them, request the changes needed, or close them with an explanation.',
+      confidence: prs.sample.truncated ? 'medium' : 'high',
+      evidenceUrl: `${repoUrl}/pulls?q=${encodeURIComponent('is:pr is:open sort:created-asc')}`,
+    });
+  }
+
+  if (
+    medianMergeDays !== null &&
+    medianMergeDays > 30 &&
+    prs.mergedDurationDays.length >= 5
+  ) {
+    findings.push({
+      id: 'pullRequests.slowMerge',
+      category: 'pullRequests',
+      severity: 'low',
+      title: 'Pull requests take a long time to merge',
+      explanation: `Across the ${prs.mergedDurationDays.length} merged pull requests sampled, the median time from opening to merge was ${medianMergeDays} days. This is an approximation from recent pull requests, not a complete history.`,
+      metric: {
+        medianMergeDays,
+        mergedPullRequestsSampled: prs.mergedDurationDays.length,
+      },
+      recommendation:
+        'If contributions are expected, a documented review turnaround helps contributors know what to expect.',
+      confidence: prs.sample.truncated ? 'medium' : 'high',
+      evidenceUrl: `${repoUrl}/pulls?q=${encodeURIComponent('is:pr is:merged')}`,
+    });
+  }
+
+  if (decided >= 10 && mergeRate !== null && mergeRate < 0.3) {
+    findings.push({
+      id: 'pullRequests.lowMergeRate',
+      category: 'pullRequests',
+      severity: 'low',
+      title: 'Most recent pull requests were closed without merging',
+      explanation: `Of the ${decided} pull requests decided in the last 90 days, ${prs.recentlyClosedUnmergedCount} were closed without merging. This is an observation about outcomes, not about whether those decisions were correct — declining out-of-scope contributions is legitimate maintenance.`,
+      metric: {
+        merged: prs.recentlyMergedCount,
+        closedUnmerged: prs.recentlyClosedUnmergedCount,
+        mergeRate: Number(mergeRate.toFixed(2)),
+      },
+      recommendation:
+        'If contributions are welcome, documenting what is in scope before someone writes code saves everyone effort.',
+      confidence: prs.sample.truncated ? 'medium' : 'high',
+      evidenceUrl: `${repoUrl}/pulls?q=${encodeURIComponent('is:pr is:closed is:unmerged')}`,
+    });
+  }
+
+  return {
+    key: 'pullRequests',
+    label: CATEGORY_LABELS.pullRequests,
+    score,
+    confidence: deriveConfidence({
+      scoredWeight,
+      totalWeight,
+      samples: [prs.sample],
+    }),
+    metrics: [
+      metric('pullRequests.open.count', 'Open pull requests examined', prs.openCount),
+      metric(
+        'pullRequests.longLived.count',
+        'Long-lived open pull requests',
+        longLivedCount,
+      ),
+      metric(
+        'pullRequests.longLived.thresholdDays',
+        'Long-lived threshold',
+        LONG_LIVED_PR_DAYS,
+        {
+          unit: 'days',
+        },
+      ),
+      metric(
+        'pullRequests.medianMergeDays',
+        'Median time to merge (approximate)',
+        medianMergeDays,
+        { unit: 'days', unknownReason: 'insufficient_data' },
+      ),
+      metric('pullRequests.merged90d', 'Merged in last 90 days', prs.recentlyMergedCount),
+      metric(
+        'pullRequests.closedUnmerged90d',
+        'Closed unmerged in last 90 days',
+        prs.recentlyClosedUnmergedCount,
+      ),
+      metric(
+        'pullRequests.sample.examined',
+        'Pull requests examined',
+        prs.sample.examined,
+      ),
+      metric(
+        'pullRequests.sample.truncated',
+        'Sample truncated',
+        String(prs.sample.truncated),
+      ),
+    ],
+    findings,
+    explanation: {
+      summary:
+        'Measures how pull requests move: how many sit open for a long time, how quickly they are merged, and what share of decided pull requests were merged.',
+      formula: describeFormula(components),
+      components,
+      limitations: [
+        `Based on a sample of up to 200 recent pull requests${prs.sample.truncated ? ', which was truncated for this repository' : ''}. Every derived figure is approximate.`,
+        'Review latency and approval counts are not measured; reading them costs more requests than the analysis budget allows.',
+        'RepoSignal reports observed outcomes only. A pull request closed without merging may have been correctly declined, and that distinction is not observable.',
+        'Draft pull requests are counted as open, since GitHub reports them that way.',
+      ],
+    },
+  };
+}

--- a/src/lib/scoring/repository.ts
+++ b/src/lib/scoring/repository.ts
@@ -1,0 +1,238 @@
+import type { CategoryScore, Finding, Metric } from '@/types/analysis';
+import type { RepositorySnapshot } from '@/types/snapshot';
+
+import {
+  combine,
+  component,
+  describeFormula,
+  deriveConfidence,
+  metric,
+} from './primitives';
+import { CATEGORY_LABELS } from './weights';
+
+/**
+ * Repository hygiene scoring.
+ *
+ * The interesting case in this category is branch protection, which requires
+ * elevated permissions on most repositories. RepoSignal cannot read it, and
+ * reporting "unknown" as "not protected" would penalize a repository for a
+ * permission RepoSignal does not have. So the component scores `null`, its
+ * weight is redistributed, and the UI says "unable to verify from public
+ * GitHub data" — which is the honest statement.
+ */
+
+/** A repository with at least this many topics is discoverable. */
+export const TOPIC_TARGET = 3;
+
+export function scoreRepository(snapshot: RepositorySnapshot): CategoryScore {
+  const { files, community, activity, identity } = snapshot;
+  const repoUrl = identity.htmlUrl;
+
+  const hasLockfile = files.lockfiles.length > 0;
+  const hasTags = activity.tagCount !== null ? activity.tagCount > 0 : null;
+
+  const components = [
+    component(
+      'repository.gitignore',
+      '.gitignore',
+      files.gitignore.present ? 100 : 0,
+      15,
+      files.gitignore.present ? 'Present' : 'Absent',
+      'Present scores 100, absent scores 0.',
+    ),
+    component(
+      'repository.lockfile',
+      'Dependency lockfile',
+      hasLockfile ? 100 : 0,
+      20,
+      hasLockfile ? `Present: ${files.lockfiles.join(', ')}` : 'None detected',
+      'Any recognized lockfile scores 100, none scores 0. A lockfile makes builds reproducible.',
+    ),
+    component(
+      'repository.dependencyAutomation',
+      'Dependency update automation',
+      files.dependencyAutomation.present ? 100 : 0,
+      15,
+      files.dependencyAutomation.present
+        ? `Configured at ${files.dependencyAutomation.path}`
+        : 'Not configured',
+      'Dependabot or Renovate configuration scores 100, absent scores 0.',
+    ),
+    component(
+      'repository.codeowners',
+      'CODEOWNERS',
+      files.codeowners.present ? 100 : 0,
+      10,
+      files.codeowners.present ? 'Present' : 'Absent',
+      'Present scores 100, absent scores 0.',
+    ),
+    component(
+      'repository.tags',
+      'Release tags',
+      hasTags === null ? null : hasTags ? 100 : 0,
+      15,
+      activity.tagCount === null
+        ? 'Could not be read'
+        : `${activity.tagCount} tag${activity.tagCount === 1 ? '' : 's'}`,
+      'At least one tag scores 100, none scores 0. Unreadable scores null and its weight is redistributed.',
+    ),
+    component(
+      'repository.metadata',
+      'Description and topics',
+      metadataScore(community.hasDescription, community.topicCount),
+      15,
+      `${community.hasDescription ? 'Description set' : 'No description'}, ${community.topicCount} topic${community.topicCount === 1 ? '' : 's'}`,
+      `A description scores 50, ${TOPIC_TARGET} or more topics scores the other 50.`,
+    ),
+    component(
+      'repository.branchProtection',
+      'Default branch protection',
+      // null, deliberately: see the module comment.
+      community.defaultBranchProtected === null
+        ? null
+        : community.defaultBranchProtected
+          ? 100
+          : 0,
+      10,
+      community.defaultBranchProtected === null
+        ? 'Unable to verify from public GitHub data'
+        : community.defaultBranchProtected
+          ? 'Protected'
+          : 'Not protected',
+      'Protected scores 100, unprotected scores 0. Requires elevated permissions to read; when unreadable it scores null and its weight is redistributed.',
+    ),
+  ];
+
+  const { score, scoredWeight, totalWeight } = combine(components);
+  const findings: Finding[] = [];
+
+  if (!hasLockfile) {
+    findings.push({
+      id: 'repository.lockfile.missing',
+      category: 'repository',
+      severity: 'medium',
+      title: 'No dependency lockfile',
+      explanation:
+        'No lockfile was found at the repository root. Without one, two installs of the same commit can resolve different dependency versions, so a build that works today may not tomorrow.',
+      metric: { lockfilesFound: 0 },
+      recommendation:
+        'Commit the lockfile your package manager generates rather than ignoring it.',
+      confidence: 'medium',
+      evidenceUrl: repoUrl,
+    });
+  }
+
+  if (!files.dependencyAutomation.present) {
+    findings.push({
+      id: 'repository.dependencyAutomation.missing',
+      category: 'repository',
+      severity: 'low',
+      title: 'No automated dependency updates',
+      explanation:
+        'Neither a Dependabot nor a Renovate configuration was found. Dependency updates, including security patches, have to be noticed and applied by hand.',
+      metric: { dependencyAutomation: 'false' },
+      recommendation:
+        'Add .github/dependabot.yml, or a Renovate configuration, to receive update pull requests automatically.',
+      confidence: 'high',
+      evidenceUrl: repoUrl,
+    });
+  }
+
+  if (activity.tagCount === 0) {
+    findings.push({
+      id: 'repository.tags.none',
+      category: 'repository',
+      severity: 'low',
+      title: 'No release tags',
+      explanation:
+        'The repository has no tags. Consumers have no way to pin a specific version, and there is no record of what changed between points in time.',
+      metric: { tagCount: 0 },
+      recommendation: 'Tag releases, following semantic versioning where it applies.',
+      confidence: 'high',
+      evidenceUrl: `${repoUrl}/tags`,
+    });
+  }
+
+  if (!community.hasDescription) {
+    findings.push({
+      id: 'repository.description.missing',
+      category: 'repository',
+      severity: 'info',
+      title: 'No repository description',
+      explanation:
+        'The repository has no description, so anyone finding it through search or a listing has only the name to go on.',
+      metric: { hasDescription: 'false' },
+      recommendation: 'Add a one-line description in the repository settings.',
+      confidence: 'high',
+      evidenceUrl: repoUrl,
+    });
+  }
+
+  const metrics: Metric[] = [
+    metric(
+      'repository.gitignore.present',
+      '.gitignore present',
+      String(files.gitignore.present),
+    ),
+    metric('repository.lockfiles.count', 'Lockfiles found', files.lockfiles.length),
+    metric(
+      'repository.lockfiles.names',
+      'Lockfiles',
+      files.lockfiles.length > 0 ? files.lockfiles.join(', ') : null,
+      { unknownReason: 'not_applicable' },
+    ),
+    metric(
+      'repository.dependencyAutomation.present',
+      'Dependency automation configured',
+      String(files.dependencyAutomation.present),
+    ),
+    metric(
+      'repository.codeowners.present',
+      'CODEOWNERS present',
+      String(files.codeowners.present),
+    ),
+    metric('repository.tags.count', 'Release tags', activity.tagCount, {
+      unknownReason: 'not_retrieved',
+    }),
+    metric('repository.topics.count', 'Topics', community.topicCount),
+    metric(
+      'repository.branchProtection',
+      'Default branch protected',
+      community.defaultBranchProtected === null
+        ? null
+        : String(community.defaultBranchProtected),
+      { unknownReason: 'requires_elevated_permissions' },
+    ),
+  ];
+
+  const limitations = [
+    'File presence is checked at the repository root and in .github only.',
+    'Lockfile detection covers common ecosystems by filename; an unrecognized package manager will read as having none.',
+  ];
+
+  if (community.defaultBranchProtected === null) {
+    limitations.push(
+      'Branch protection: unable to verify from public GitHub data. Reading it requires administrative access to the repository, so it was excluded from the score rather than assumed absent.',
+    );
+  }
+
+  return {
+    key: 'repository',
+    label: CATEGORY_LABELS.repository,
+    score,
+    confidence: deriveConfidence({ scoredWeight, totalWeight }),
+    metrics,
+    findings,
+    explanation: {
+      summary:
+        'Measures the repository-level practices that make a project reproducible, maintainable, and discoverable.',
+      formula: describeFormula(components),
+      components,
+      limitations,
+    },
+  };
+}
+
+function metadataScore(hasDescription: boolean, topicCount: number): number {
+  return (hasDescription ? 50 : 0) + (topicCount >= TOPIC_TARGET ? 50 : 0);
+}

--- a/src/lib/scoring/security.ts
+++ b/src/lib/scoring/security.ts
@@ -1,0 +1,161 @@
+import type { CategoryScore, Finding } from '@/types/analysis';
+import type { RepositorySnapshot } from '@/types/snapshot';
+
+import {
+  combine,
+  component,
+  describeFormula,
+  deriveConfidence,
+  metric,
+} from './primitives';
+import { CATEGORY_LABELS } from './weights';
+
+/**
+ * Security hygiene scoring.
+ *
+ * The name is the point. This category observes **practices**, not posture.
+ * RepoSignal does not scan for vulnerabilities, look for secrets, resolve
+ * dependency CVEs, or read code. A repository scoring 100 here has adopted
+ * four visible practices; it has not been assessed as secure, and nothing in
+ * this module may claim otherwise.
+ *
+ * That constraint is enforced by a test asserting no user-facing string here
+ * says a repository is secure.
+ */
+
+export function scoreSecurity(snapshot: RepositorySnapshot): CategoryScore {
+  const { files, identity } = snapshot;
+  const repoUrl = identity.htmlUrl;
+
+  const hasLockfile = files.lockfiles.length > 0;
+  const scanners = files.securityScanningWorkflows;
+  const hasScanning = scanners.length > 0;
+
+  const components = [
+    component(
+      'security.policy',
+      'Security policy',
+      files.security.present ? 100 : 0,
+      30,
+      files.security.present ? `Present at ${files.security.path}` : 'Absent',
+      'A SECURITY.md scores 100, absent scores 0. It tells a reporter where to send a vulnerability privately.',
+    ),
+    component(
+      'security.dependencyAutomation',
+      'Dependency update automation',
+      files.dependencyAutomation.present ? 100 : 0,
+      25,
+      files.dependencyAutomation.present
+        ? `Configured at ${files.dependencyAutomation.path}`
+        : 'Not configured',
+      'Dependabot or Renovate configuration scores 100, absent scores 0.',
+    ),
+    component(
+      'security.scanning',
+      'Security scanning in CI',
+      hasScanning ? 100 : 0,
+      25,
+      hasScanning ? `Detected: ${scanners.join(', ')}` : 'None detected',
+      'A recognized scanning step in a workflow file scores 100, none scores 0.',
+    ),
+    component(
+      'security.lockfile',
+      'Committed lockfile',
+      hasLockfile ? 100 : 0,
+      20,
+      hasLockfile ? `Present: ${files.lockfiles.join(', ')}` : 'None detected',
+      'Any recognized lockfile scores 100, none scores 0. Pinned dependencies make what is installed auditable.',
+    ),
+  ];
+
+  const { score, scoredWeight, totalWeight } = combine(components);
+  const findings: Finding[] = [];
+
+  if (!files.security.present) {
+    findings.push({
+      id: 'security.policy.missing',
+      category: 'security',
+      severity: 'medium',
+      title: 'No security policy',
+      explanation:
+        'No SECURITY.md was found. Someone who discovers a vulnerability has no documented private channel, which makes public disclosure in an issue the path of least resistance.',
+      metric: { securityPolicyPresent: 'false' },
+      recommendation:
+        'Add SECURITY.md describing how to report a vulnerability privately and what response to expect.',
+      confidence: 'high',
+      evidenceUrl: repoUrl,
+    });
+  }
+
+  if (!hasScanning) {
+    findings.push({
+      id: 'security.scanning.absent',
+      category: 'security',
+      severity: 'low',
+      title: 'No security scanning detected in CI',
+      explanation:
+        'No recognized security scanning step was found in the repository workflow files RepoSignal examined. This reflects what is declared in those files, not whether scanning happens by some other means.',
+      metric: { scannersDetected: 0 },
+      recommendation:
+        'Consider adding a scanning step such as CodeQL or a dependency review action to CI.',
+      confidence: 'medium',
+      evidenceUrl: `${repoUrl}/actions`,
+    });
+  }
+
+  if (!files.dependencyAutomation.present) {
+    findings.push({
+      id: 'security.dependencyAutomation.missing',
+      category: 'security',
+      severity: 'medium',
+      title: 'Dependency updates are not automated',
+      explanation:
+        'Neither a Dependabot nor a Renovate configuration was found. Security patches in dependencies have to be noticed and applied manually, which typically means later.',
+      metric: { dependencyAutomation: 'false' },
+      recommendation:
+        'Add .github/dependabot.yml, or a Renovate configuration, to receive dependency update pull requests automatically.',
+      confidence: 'high',
+      evidenceUrl: repoUrl,
+    });
+  }
+
+  return {
+    key: 'security',
+    label: CATEGORY_LABELS.security,
+    score,
+    confidence: deriveConfidence({ scoredWeight, totalWeight }),
+    metrics: [
+      metric(
+        'security.policy.present',
+        'SECURITY.md present',
+        String(files.security.present),
+      ),
+      metric(
+        'security.dependencyAutomation.present',
+        'Dependency automation configured',
+        String(files.dependencyAutomation.present),
+      ),
+      metric('security.scanning.count', 'Scanning tools detected', scanners.length),
+      metric(
+        'security.scanning.tools',
+        'Scanning tools',
+        scanners.length > 0 ? scanners.join(', ') : null,
+        { unknownReason: 'not_applicable' },
+      ),
+      metric('security.lockfile.present', 'Lockfile committed', String(hasLockfile)),
+    ],
+    findings,
+    explanation: {
+      summary:
+        'Measures observable security practices: a documented reporting channel, automated dependency updates, scanning declared in CI, and a committed lockfile.',
+      formula: describeFormula(components),
+      components,
+      limitations: [
+        'This category measures practices, not posture. A high score means these practices were observed — it does not mean the repository is free of vulnerabilities, and RepoSignal makes no such claim.',
+        'No scanning is performed. RepoSignal does not analyze code, resolve dependency versions against advisory databases, or look for secrets.',
+        'Scanning detection is text matching against a bounded sample of workflow files. Scanning configured elsewhere, or in a workflow beyond the sample, is not detected.',
+        'GitHub features such as private vulnerability reporting and secret scanning alerts are not readable from public data and are not assessed.',
+      ],
+    },
+  };
+}

--- a/src/lib/scoring/weights.ts
+++ b/src/lib/scoring/weights.ts
@@ -1,0 +1,51 @@
+import type { CategoryKey } from '@/types/analysis';
+
+/**
+ * The scoring algorithm version.
+ *
+ * Every stored analysis records this. Any change to a weight, threshold, or
+ * formula anywhere in `src/lib/scoring` requires bumping it and adding an
+ * entry to `docs/SCORING.md`, so a historical result stays interpretable
+ * against the rules that produced it.
+ */
+export const SCORING_VERSION = '1.0.0';
+
+/**
+ * Declared category weights, summing to 100.
+ *
+ * Six categories are weighted equally at 15 because RepoSignal has no evidence
+ * that any one dimension of engineering health predicts another better —
+ * asserting otherwise would be fabricated precision. Security Hygiene is
+ * weighted lower at 10 because it observes the fewest independent signals, so
+ * a single missing file moves it further than it should move a total.
+ */
+export const CATEGORY_WEIGHTS: Record<CategoryKey, number> = {
+  activity: 15,
+  pullRequests: 15,
+  issues: 15,
+  ci: 15,
+  documentation: 15,
+  repository: 15,
+  security: 10,
+};
+
+export const CATEGORY_LABELS: Record<CategoryKey, string> = {
+  activity: 'Repository Activity',
+  pullRequests: 'Pull Request Health',
+  issues: 'Issue Health',
+  ci: 'CI Health',
+  documentation: 'Documentation',
+  repository: 'Repository Hygiene',
+  // Deliberately "Hygiene", never "Score": RepoSignal observes practices, not
+  // security posture, and the name is part of not overstating that.
+  security: 'Security Hygiene',
+};
+
+/**
+ * Below this many scored categories, the overall score is `null`.
+ *
+ * Averaging two categories and presenting the result as an engineering health
+ * score implies far more coverage than three of fourteen possible signals
+ * provide.
+ */
+export const MINIMUM_SCORED_CATEGORIES = 3;

--- a/tests/support/snapshot-builder.ts
+++ b/tests/support/snapshot-builder.ts
@@ -1,0 +1,205 @@
+import type {
+  ActivitySnapshot,
+  CiSnapshot,
+  CommunitySnapshot,
+  FilePresence,
+  FileSnapshot,
+  IssueSnapshot,
+  PullRequestSnapshot,
+  RepositorySnapshot,
+} from '@/types/snapshot';
+
+/**
+ * Builds `RepositorySnapshot` values for scoring tests.
+ *
+ * Scoring is pure over this type, so tests construct plain objects rather than
+ * recorded HTTP fixtures. That is the practical payoff of the normalization
+ * boundary: a test for "median PR age at exactly 90 days" is three lines, not
+ * a curated JSON file.
+ */
+
+/** The fixed clock every scoring test uses. */
+export const NOW = new Date('2026-06-01T00:00:00Z');
+
+export function daysAgo(days: number, from: Date = NOW): string {
+  return new Date(from.getTime() - days * 86_400_000).toISOString();
+}
+
+export function present(overrides: Partial<FilePresence> = {}): FilePresence {
+  return {
+    present: true,
+    path: 'README.md',
+    sizeBytes: 5000,
+    htmlUrl: 'https://github.com/acme/widget/blob/main/README.md',
+    ...overrides,
+  };
+}
+
+export const ABSENT: FilePresence = {
+  present: false,
+  path: null,
+  sizeBytes: null,
+  htmlUrl: null,
+};
+
+function defaultFiles(): FileSnapshot {
+  return {
+    readme: ABSENT,
+    contributing: ABSENT,
+    license: ABSENT,
+    security: ABSENT,
+    codeOfConduct: ABSENT,
+    changelog: ABSENT,
+    codeowners: ABSENT,
+    gitignore: ABSENT,
+    issueTemplates: ABSENT,
+    pullRequestTemplate: ABSENT,
+    docsDirectory: ABSENT,
+    lockfiles: [],
+    dependencyAutomation: ABSENT,
+    securityScanningWorkflows: [],
+  };
+}
+
+/** Every documentation and hygiene file present, for "healthy project" cases. */
+export function allFilesPresent(): FileSnapshot {
+  return {
+    readme: present({ path: 'README.md', sizeBytes: 8000 }),
+    contributing: present({ path: 'CONTRIBUTING.md', sizeBytes: 3000 }),
+    license: present({ path: 'LICENSE', sizeBytes: 1000 }),
+    security: present({ path: 'SECURITY.md', sizeBytes: 900 }),
+    codeOfConduct: present({ path: 'CODE_OF_CONDUCT.md', sizeBytes: 3000 }),
+    changelog: present({ path: 'CHANGELOG.md', sizeBytes: 2000 }),
+    codeowners: present({ path: '.github/CODEOWNERS', sizeBytes: 100 }),
+    gitignore: present({ path: '.gitignore', sizeBytes: 400 }),
+    issueTemplates: present({ path: '.github/ISSUE_TEMPLATE', sizeBytes: null }),
+    pullRequestTemplate: present({
+      path: '.github/pull_request_template.md',
+      sizeBytes: null,
+    }),
+    docsDirectory: present({ path: 'docs', sizeBytes: null }),
+    lockfiles: ['package-lock.json'],
+    dependencyAutomation: present({ path: '.github/dependabot.yml', sizeBytes: 300 }),
+    securityScanningWorkflows: ['github/codeql-action'],
+  };
+}
+
+function defaultActivity(): ActivitySnapshot {
+  return {
+    createdAt: daysAgo(1000),
+    pushedAt: daysAgo(3),
+    weeklyCommits: Array.from({ length: 52 }, () => 5),
+    contributorCount: 20,
+    releases: [
+      { tagName: 'v1.0.0', publishedAt: daysAgo(200), isPrerelease: false, htmlUrl: '' },
+      { tagName: 'v1.1.0', publishedAt: daysAgo(140), isPrerelease: false, htmlUrl: '' },
+      { tagName: 'v1.2.0', publishedAt: daysAgo(80), isPrerelease: false, htmlUrl: '' },
+      { tagName: 'v1.3.0', publishedAt: daysAgo(20), isPrerelease: false, htmlUrl: '' },
+    ],
+    tagCount: 4,
+    stars: 1200,
+    forks: 90,
+    isArchived: false,
+  };
+}
+
+function defaultIssues(): IssueSnapshot {
+  return {
+    openCount: 10,
+    openAgeDays: [5, 10, 20, 30, 40, 50, 60, 70, 80, 90],
+    openInactiveDays: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+    createdLast90Days: 20,
+    closedLast90Days: 22,
+    sample: { examined: 30, truncated: false },
+  };
+}
+
+function defaultPullRequests(): PullRequestSnapshot {
+  return {
+    openCount: 5,
+    openAgeDays: [1, 3, 5, 8, 12],
+    mergedDurationDays: [1, 1, 2, 2, 3, 4],
+    recentlyMergedCount: 25,
+    recentlyClosedUnmergedCount: 3,
+    sample: { examined: 40, truncated: false },
+  };
+}
+
+function defaultCi(): CiSnapshot {
+  return {
+    workflowCount: 2,
+    workflowFileNames: ['.github/workflows/ci.yml'],
+    recentRunConclusions: Array.from({ length: 20 }, () => 'success' as const),
+    latestCommitStatus: 'success',
+    sample: { examined: 20, truncated: false },
+  };
+}
+
+function defaultCommunity(): CommunitySnapshot {
+  return {
+    hasDescription: true,
+    hasHomepage: true,
+    topicCount: 5,
+    hasIssuesEnabled: true,
+    defaultBranchProtected: null,
+  };
+}
+
+export interface SnapshotOverrides {
+  activity?: Partial<ActivitySnapshot>;
+  issues?: Partial<IssueSnapshot> | null;
+  pullRequests?: Partial<PullRequestSnapshot> | null;
+  ci?: Partial<CiSnapshot>;
+  files?: Partial<FileSnapshot>;
+  community?: Partial<CommunitySnapshot>;
+  identity?: Partial<RepositorySnapshot['identity']>;
+  collection?: Partial<RepositorySnapshot['collection']>;
+}
+
+/**
+ * A snapshot of a healthy repository, with everything present and recent.
+ * Tests override only the field under examination.
+ */
+export function buildSnapshot(overrides: SnapshotOverrides = {}): RepositorySnapshot {
+  return {
+    capturedAt: NOW.toISOString(),
+    identity: {
+      githubId: 1,
+      owner: 'acme',
+      name: 'widget',
+      fullName: 'acme/widget',
+      htmlUrl: 'https://github.com/acme/widget',
+      description: 'A widget',
+      isArchived: overrides.activity?.isArchived ?? false,
+      isFork: false,
+      defaultBranch: 'main',
+      ...overrides.identity,
+    },
+    activity: { ...defaultActivity(), ...overrides.activity },
+    issues:
+      overrides.issues === null ? null : { ...defaultIssues(), ...overrides.issues },
+    pullRequests:
+      overrides.pullRequests === null
+        ? null
+        : { ...defaultPullRequests(), ...overrides.pullRequests },
+    ci: { ...defaultCi(), ...overrides.ci },
+    files: { ...defaultFiles(), ...overrides.files },
+    community: { ...defaultCommunity(), ...overrides.community },
+    collection: {
+      requestsMade: 12,
+      failures: [],
+      rateLimitRemaining: 4900,
+      ...overrides.collection,
+    },
+  };
+}
+
+/** A snapshot with every observable signal in its best state. */
+export function buildHealthySnapshot(
+  overrides: SnapshotOverrides = {},
+): RepositorySnapshot {
+  return buildSnapshot({
+    ...overrides,
+    files: { ...allFilesPresent(), ...overrides.files },
+  });
+}

--- a/tests/unit/scoring/categories.test.ts
+++ b/tests/unit/scoring/categories.test.ts
@@ -1,0 +1,739 @@
+import { describe, expect, it } from 'vitest';
+
+import { releaseCadenceScore, scoreActivity } from '@/lib/scoring/activity';
+import {
+  CONSECUTIVE_FAILURE_THRESHOLD,
+  countLeadingFailures,
+  scoreCi,
+} from '@/lib/scoring/ci';
+import { README_STUB_BYTES, scoreDocumentation } from '@/lib/scoring/documentation';
+import { STALE_ISSUE_DAYS, scoreIssues } from '@/lib/scoring/issues';
+import { LONG_LIVED_PR_DAYS, scorePullRequests } from '@/lib/scoring/pull-requests';
+import { scoreRepository } from '@/lib/scoring/repository';
+import { scoreSecurity } from '@/lib/scoring/security';
+
+import {
+  ABSENT,
+  NOW,
+  allFilesPresent,
+  buildHealthySnapshot,
+  buildSnapshot,
+  daysAgo,
+  present,
+} from '../../support/snapshot-builder';
+
+describe('scoreDocumentation', () => {
+  it('scores 100 with every file present and substantial', () => {
+    expect(scoreDocumentation(buildHealthySnapshot()).score).toBe(100);
+  });
+
+  it('scores 0 with nothing present — this category is always observable', () => {
+    const result = scoreDocumentation(buildSnapshot());
+    expect(result.score).toBe(0);
+    // Distinct from null: file absence is an observation, not missing data.
+    expect(result.score).not.toBeNull();
+  });
+
+  it.each([
+    ['README', 'readme', 'documentation.readme.missing'],
+    ['LICENSE', 'license', 'documentation.license.missing'],
+    ['CONTRIBUTING', 'contributing', 'documentation.contributing.missing'],
+  ])('emits a finding when %s is absent', (_label, key, findingId) => {
+    const result = scoreDocumentation(buildHealthySnapshot({ files: { [key]: ABSENT } }));
+    expect(result.findings.map((f) => f.id)).toContain(findingId);
+  });
+
+  it('rates a missing LICENSE as high severity', () => {
+    const result = scoreDocumentation(
+      buildHealthySnapshot({ files: { license: ABSENT } }),
+    );
+    const finding = result.findings.find((f) => f.id === 'documentation.license.missing');
+    expect(finding?.severity).toBe('high');
+  });
+
+  describe('README stub boundary', () => {
+    it(`treats exactly ${README_STUB_BYTES} bytes as substantial`, () => {
+      const result = scoreDocumentation(
+        buildHealthySnapshot({
+          files: { readme: present({ sizeBytes: README_STUB_BYTES }) },
+        }),
+      );
+      expect(result.findings.map((f) => f.id)).not.toContain('documentation.readme.stub');
+    });
+
+    it(`treats one byte below ${README_STUB_BYTES} as a stub`, () => {
+      const result = scoreDocumentation(
+        buildHealthySnapshot({
+          files: { readme: present({ sizeBytes: README_STUB_BYTES - 1 }) },
+        }),
+      );
+      expect(result.findings.map((f) => f.id)).toContain('documentation.readme.stub');
+    });
+
+    it('does not guess when the size is unknown', () => {
+      const result = scoreDocumentation(
+        buildHealthySnapshot({ files: { readme: present({ sizeBytes: null }) } }),
+      );
+      expect(result.findings.map((f) => f.id)).not.toContain('documentation.readme.stub');
+    });
+  });
+
+  it('discloses its own limitations', () => {
+    const explanation = scoreDocumentation(buildHealthySnapshot()).explanation;
+    expect(explanation.limitations.length).toBeGreaterThan(0);
+    expect(explanation.components.length).toBeGreaterThan(0);
+    expect(explanation.formula).not.toBe('');
+  });
+});
+
+describe('scoreRepository', () => {
+  it('scores highly with full hygiene', () => {
+    const result = scoreRepository(
+      buildHealthySnapshot({ community: { defaultBranchProtected: true } }),
+    );
+    expect(result.score).toBe(100);
+  });
+
+  it('excludes unverifiable branch protection rather than scoring it zero', () => {
+    // The critical case: reading branch protection needs admin access, so a
+    // null must never be read as "not protected".
+    const withUnknown = scoreRepository(
+      buildHealthySnapshot({ community: { defaultBranchProtected: null } }),
+    );
+    const withProtection = scoreRepository(
+      buildHealthySnapshot({ community: { defaultBranchProtected: true } }),
+    );
+
+    expect(withUnknown.score).toBe(withProtection.score);
+
+    const component = withUnknown.explanation.components.find(
+      (c) => c.id === 'repository.branchProtection',
+    );
+    expect(component?.score).toBeNull();
+  });
+
+  it('scores an explicitly unprotected branch lower than an unverifiable one', () => {
+    const unprotected = scoreRepository(
+      buildHealthySnapshot({ community: { defaultBranchProtected: false } }),
+    );
+    const unknown = scoreRepository(
+      buildHealthySnapshot({ community: { defaultBranchProtected: null } }),
+    );
+    expect(unprotected.score).toBeLessThan(unknown.score ?? 0);
+  });
+
+  it('says "unable to verify" in the limitations when protection is unreadable', () => {
+    const result = scoreRepository(
+      buildHealthySnapshot({ community: { defaultBranchProtected: null } }),
+    );
+    expect(result.explanation.limitations.join(' ')).toMatch(/unable to verify/i);
+  });
+
+  it.each([
+    ['npm', 'package-lock.json'],
+    ['pnpm', 'pnpm-lock.yaml'],
+    ['cargo', 'Cargo.lock'],
+    ['poetry', 'poetry.lock'],
+  ])('accepts the %s lockfile', (_label, lockfile) => {
+    const result = scoreRepository(
+      buildHealthySnapshot({ files: { lockfiles: [lockfile] } }),
+    );
+    expect(result.findings.map((f) => f.id)).not.toContain('repository.lockfile.missing');
+  });
+
+  it('reports a missing lockfile', () => {
+    const result = scoreRepository(buildHealthySnapshot({ files: { lockfiles: [] } }));
+    expect(result.findings.map((f) => f.id)).toContain('repository.lockfile.missing');
+  });
+
+  it('keeps the tag component null when the tag count is unreadable', () => {
+    const result = scoreRepository(
+      buildHealthySnapshot({ activity: { tagCount: null } }),
+    );
+    const component = result.explanation.components.find(
+      (c) => c.id === 'repository.tags',
+    );
+    expect(component?.score).toBeNull();
+  });
+});
+
+describe('scoreSecurity', () => {
+  it('scores 100 with every observable practice present', () => {
+    expect(scoreSecurity(buildHealthySnapshot()).score).toBe(100);
+  });
+
+  it('scores 0 with none present', () => {
+    expect(scoreSecurity(buildSnapshot()).score).toBe(0);
+  });
+
+  it('never claims a repository is secure', () => {
+    // The constraint that gives this category its name. A perfect score means
+    // four practices were observed, not that the repository is secure.
+    const result = scoreSecurity(buildHealthySnapshot());
+
+    const userFacingText = [
+      result.label,
+      result.explanation.summary,
+      ...result.explanation.limitations,
+      ...result.explanation.components.flatMap((c) => [c.label, c.observed, c.rule]),
+      ...result.findings.flatMap((f) => [f.title, f.explanation, f.recommendation]),
+    ].join(' ');
+
+    expect(userFacingText).not.toMatch(/\bis secure\b/i);
+    expect(userFacingText).not.toMatch(/\bsecure repository\b/i);
+    expect(userFacingText).not.toMatch(/\bno vulnerabilities\b/i);
+    expect(result.label).toBe('Security Hygiene');
+    expect(result.label).not.toMatch(/security score/i);
+  });
+
+  it('states plainly that it measures practices, not posture', () => {
+    const limitations =
+      scoreSecurity(buildHealthySnapshot()).explanation.limitations.join(' ');
+    expect(limitations).toMatch(/practices, not posture/i);
+  });
+
+  it.each([
+    ['CodeQL', 'github/codeql-action'],
+    ['Trivy', 'aquasecurity/trivy-action'],
+    ['npm audit', 'npm audit'],
+  ])('recognizes %s as scanning', (_label, scanner) => {
+    const result = scoreSecurity(
+      buildHealthySnapshot({ files: { securityScanningWorkflows: [scanner] } }),
+    );
+    expect(result.findings.map((f) => f.id)).not.toContain('security.scanning.absent');
+  });
+
+  it('reports a missing security policy', () => {
+    const result = scoreSecurity(buildHealthySnapshot({ files: { security: ABSENT } }));
+    expect(result.findings.map((f) => f.id)).toContain('security.policy.missing');
+  });
+});
+
+describe('scoreIssues', () => {
+  it('returns null when issues are disabled, never zero', () => {
+    const result = scoreIssues(buildSnapshot({ issues: null }));
+    expect(result.score).toBeNull();
+    expect(result.findings[0]?.id).toBe('issues.disabled');
+  });
+
+  it('scores a well-tended backlog highly', () => {
+    expect(scoreIssues(buildHealthySnapshot()).score).toBeGreaterThan(85);
+  });
+
+  describe(`stale boundary at ${STALE_ISSUE_DAYS} days`, () => {
+    it(`counts exactly ${STALE_ISSUE_DAYS} days as stale`, () => {
+      const result = scoreIssues(
+        buildSnapshot({
+          issues: {
+            openCount: 1,
+            openInactiveDays: [STALE_ISSUE_DAYS],
+            openAgeDays: [STALE_ISSUE_DAYS],
+          },
+        }),
+      );
+      const staleMetric = result.metrics.find((m) => m.id === 'issues.stale.count');
+      expect(staleMetric?.value).toBe(1);
+    });
+
+    it(`does not count one day below ${STALE_ISSUE_DAYS}`, () => {
+      const result = scoreIssues(
+        buildSnapshot({
+          issues: {
+            openCount: 1,
+            openInactiveDays: [STALE_ISSUE_DAYS - 1],
+            openAgeDays: [STALE_ISSUE_DAYS - 1],
+          },
+        }),
+      );
+      const staleMetric = result.metrics.find((m) => m.id === 'issues.stale.count');
+      expect(staleMetric?.value).toBe(0);
+    });
+  });
+
+  it('raises a high-severity finding when most issues are stale', () => {
+    const result = scoreIssues(
+      buildSnapshot({
+        issues: {
+          openCount: 10,
+          openInactiveDays: Array.from({ length: 10 }, () => 400),
+          openAgeDays: Array.from({ length: 10 }, () => 500),
+        },
+      }),
+    );
+    const finding = result.findings.find((f) => f.id === 'issues.stale.backlog');
+    expect(finding?.severity).toBe('high');
+    expect(finding?.evidenceUrl).toContain('github.com/acme/widget/issues');
+  });
+
+  it('lowers confidence when the sample was truncated', () => {
+    const complete = scoreIssues(buildHealthySnapshot());
+    const truncated = scoreIssues(
+      buildSnapshot({ issues: { sample: { examined: 300, truncated: true } } }),
+    );
+    expect(truncated.confidence).not.toBe('high');
+    expect(complete.confidence).toBe('high');
+  });
+
+  it('marks findings from a truncated sample as medium confidence at best', () => {
+    const result = scoreIssues(
+      buildSnapshot({
+        issues: {
+          openCount: 10,
+          openInactiveDays: Array.from({ length: 10 }, () => 400),
+          openAgeDays: Array.from({ length: 10 }, () => 500),
+          sample: { examined: 300, truncated: true },
+        },
+      }),
+    );
+    const finding = result.findings.find((f) => f.id === 'issues.stale.backlog');
+    expect(finding?.confidence).toBe('medium');
+  });
+
+  it('reports a growing backlog', () => {
+    const result = scoreIssues(
+      buildSnapshot({ issues: { createdLast90Days: 40, closedLast90Days: 5 } }),
+    );
+    expect(result.findings.map((f) => f.id)).toContain('issues.backlog.growing');
+  });
+
+  it('describes observations rather than attributing intent', () => {
+    const result = scoreIssues(
+      buildSnapshot({
+        issues: {
+          openCount: 10,
+          openInactiveDays: Array.from({ length: 10 }, () => 400),
+          openAgeDays: Array.from({ length: 10 }, () => 500),
+        },
+      }),
+    );
+    const text = result.findings.map((f) => `${f.title} ${f.explanation}`).join(' ');
+    expect(text).not.toMatch(/ignor(e|ing|ed)/i);
+    expect(text).not.toMatch(/neglect/i);
+    expect(text).not.toMatch(/lazy|careless/i);
+  });
+
+  it('notes an empty backlog without penalising it', () => {
+    const result = scoreIssues(
+      buildSnapshot({
+        issues: {
+          openCount: 0,
+          openAgeDays: [],
+          openInactiveDays: [],
+          createdLast90Days: 0,
+          closedLast90Days: 5,
+        },
+      }),
+    );
+    expect(result.findings.map((f) => f.id)).toContain('issues.backlog.empty');
+    expect(result.findings.find((f) => f.id === 'issues.backlog.empty')?.severity).toBe(
+      'info',
+    );
+  });
+});
+
+describe('scorePullRequests', () => {
+  it('returns null when there have never been pull requests', () => {
+    const result = scorePullRequests(buildSnapshot({ pullRequests: null }));
+    expect(result.score).toBeNull();
+    expect(result.findings[0]?.id).toBe('pullRequests.none');
+  });
+
+  it('scores a fast-merging project highly', () => {
+    expect(scorePullRequests(buildHealthySnapshot()).score).toBeGreaterThan(85);
+  });
+
+  it('uses the median so one ancient merge cannot distort the result', () => {
+    // The mean of [1,1,2,2,3,1500] is 251 days; the median is 2.
+    const result = scorePullRequests(
+      buildSnapshot({ pullRequests: { mergedDurationDays: [1, 1, 2, 2, 3, 1500] } }),
+    );
+    const metric = result.metrics.find((m) => m.id === 'pullRequests.medianMergeDays');
+    expect(metric?.value).toBe(2);
+  });
+
+  describe(`long-lived boundary at ${LONG_LIVED_PR_DAYS} days`, () => {
+    it(`counts exactly ${LONG_LIVED_PR_DAYS} days as long-lived`, () => {
+      const result = scorePullRequests(
+        buildSnapshot({ pullRequests: { openAgeDays: [LONG_LIVED_PR_DAYS] } }),
+      );
+      const metric = result.metrics.find((m) => m.id === 'pullRequests.longLived.count');
+      expect(metric?.value).toBe(1);
+    });
+
+    it(`does not count one day below ${LONG_LIVED_PR_DAYS}`, () => {
+      const result = scorePullRequests(
+        buildSnapshot({ pullRequests: { openAgeDays: [LONG_LIVED_PR_DAYS - 1] } }),
+      );
+      const metric = result.metrics.find((m) => m.id === 'pullRequests.longLived.count');
+      expect(metric?.value).toBe(0);
+    });
+  });
+
+  it('labels sampled metrics as approximate', () => {
+    const result = scorePullRequests(buildHealthySnapshot());
+    const metric = result.metrics.find((m) => m.id === 'pullRequests.medianMergeDays');
+    expect(metric?.label).toMatch(/approximate/i);
+  });
+
+  it('keeps merge speed null when nothing has been merged', () => {
+    const result = scorePullRequests(
+      buildSnapshot({
+        pullRequests: {
+          mergedDurationDays: [],
+          recentlyMergedCount: 0,
+          recentlyClosedUnmergedCount: 0,
+        },
+      }),
+    );
+    const component = result.explanation.components.find(
+      (c) => c.id === 'pullRequests.mergeDuration',
+    );
+    expect(component?.score).toBeNull();
+  });
+
+  it('does not attribute intent to closed pull requests', () => {
+    const result = scorePullRequests(
+      buildSnapshot({
+        pullRequests: { recentlyMergedCount: 2, recentlyClosedUnmergedCount: 20 },
+      }),
+    );
+    const finding = result.findings.find((f) => f.id === 'pullRequests.lowMergeRate');
+    expect(finding?.explanation).toMatch(
+      /not about whether those decisions were correct/i,
+    );
+  });
+});
+
+describe('scoreCi', () => {
+  it('scores a passing pipeline highly', () => {
+    expect(scoreCi(buildHealthySnapshot()).score).toBeGreaterThan(90);
+  });
+
+  it('returns null when CI information could not be read', () => {
+    // The most important assertion in this category: unavailable is not failed.
+    const result = scoreCi(
+      buildSnapshot({
+        ci: {
+          workflowCount: null,
+          recentRunConclusions: [],
+          latestCommitStatus: null,
+        },
+      }),
+    );
+    expect(result.score).toBeNull();
+    expect(result.findings[0]?.id).toBe('ci.unavailable');
+  });
+
+  it('scores zero — not null — when CI is genuinely absent', () => {
+    // Readable and empty is an observation, so it is scored. This is the
+    // distinction between "no CI" and "we could not tell".
+    const result = scoreCi(
+      buildSnapshot({
+        ci: {
+          workflowCount: 0,
+          recentRunConclusions: [],
+          latestCommitStatus: 'none',
+        },
+      }),
+    );
+    expect(result.score).toBe(0);
+    expect(result.findings.map((f) => f.id)).toContain('ci.notConfigured');
+  });
+
+  it('excludes cancelled and skipped runs instead of counting them as failures', () => {
+    const allSuccess = scoreCi(
+      buildSnapshot({
+        ci: { recentRunConclusions: ['success', 'success', 'success', 'success'] },
+      }),
+    );
+    const withNoise = scoreCi(
+      buildSnapshot({
+        ci: {
+          recentRunConclusions: [
+            'success',
+            'cancelled',
+            'success',
+            'skipped',
+            'success',
+            'cancelled',
+            'success',
+          ],
+        },
+      }),
+    );
+    expect(withNoise.score).toBe(allSuccess.score);
+  });
+
+  it('reports consecutive failures at the threshold', () => {
+    const conclusions = [
+      ...Array.from({ length: CONSECUTIVE_FAILURE_THRESHOLD }, () => 'failure' as const),
+      'success' as const,
+    ];
+    const result = scoreCi(buildSnapshot({ ci: { recentRunConclusions: conclusions } }));
+    const finding = result.findings.find((f) => f.id === 'ci.consecutiveFailures');
+    expect(finding?.severity).toBe('high');
+  });
+
+  it('does not report one failure below the threshold', () => {
+    const conclusions = [
+      ...Array.from(
+        { length: CONSECUTIVE_FAILURE_THRESHOLD - 1 },
+        () => 'failure' as const,
+      ),
+      'success' as const,
+    ];
+    const result = scoreCi(buildSnapshot({ ci: { recentRunConclusions: conclusions } }));
+    expect(result.findings.map((f) => f.id)).not.toContain('ci.consecutiveFailures');
+  });
+
+  it('treats no commit status as unscorable rather than failing', () => {
+    const result = scoreCi(buildSnapshot({ ci: { latestCommitStatus: 'none' } }));
+    const component = result.explanation.components.find(
+      (c) => c.id === 'ci.latestStatus',
+    );
+    expect(component?.score).toBeNull();
+  });
+});
+
+describe('countLeadingFailures', () => {
+  it('counts an unbroken run of failures from the newest', () => {
+    expect(countLeadingFailures(['failure', 'failure', 'success', 'failure'])).toBe(2);
+  });
+
+  it('returns zero when the newest run passed', () => {
+    expect(countLeadingFailures(['success', 'failure', 'failure'])).toBe(0);
+  });
+
+  it('steps over cancelled and skipped runs without breaking the streak', () => {
+    expect(countLeadingFailures(['failure', 'cancelled', 'failure', 'success'])).toBe(2);
+  });
+
+  it('handles an empty list', () => {
+    expect(countLeadingFailures([])).toBe(0);
+  });
+});
+
+describe('scoreActivity', () => {
+  it('scores an actively developed repository highly', () => {
+    expect(scoreActivity(buildHealthySnapshot(), NOW).score).toBeGreaterThan(85);
+  });
+
+  it('does not penalise an archived repository for inactivity', () => {
+    // Archiving is a deliberate act meaning "finished", not a failure to
+    // maintain. Scoring it as neglect would punish responsible shutdown.
+    const archived = scoreActivity(
+      buildHealthySnapshot({
+        activity: { isArchived: true, pushedAt: daysAgo(1200) },
+      }),
+      NOW,
+    );
+    const abandoned = scoreActivity(
+      buildHealthySnapshot({
+        activity: { isArchived: false, pushedAt: daysAgo(1200) },
+      }),
+      NOW,
+    );
+
+    expect(archived.score).toBeGreaterThan(abandoned.score ?? 0);
+    expect(archived.findings.map((f) => f.id)).toContain('activity.archived');
+    expect(archived.findings.find((f) => f.id === 'activity.archived')?.severity).toBe(
+      'info',
+    );
+  });
+
+  it('excludes unavailable commit statistics rather than scoring them zero', () => {
+    const unknown = scoreActivity(
+      buildHealthySnapshot({ activity: { weeklyCommits: null } }),
+      NOW,
+    );
+    const component = unknown.explanation.components.find(
+      (c) => c.id === 'activity.commitCadence',
+    );
+
+    expect(component?.score).toBeNull();
+    expect(unknown.explanation.limitations.join(' ')).toMatch(
+      /not.*computing commit statistics|had not finished computing/i,
+    );
+  });
+
+  it('does not let unavailable statistics lower the score below a known-good one', () => {
+    const withStats = scoreActivity(buildHealthySnapshot(), NOW);
+    const withoutStats = scoreActivity(
+      buildHealthySnapshot({ activity: { weeklyCommits: null } }),
+      NOW,
+    );
+    expect(withoutStats.score).toBeGreaterThanOrEqual(withStats.score ?? 0);
+  });
+
+  it('reports a repository with no push in over a year', () => {
+    const result = scoreActivity(
+      buildHealthySnapshot({ activity: { pushedAt: daysAgo(400) } }),
+      NOW,
+    );
+    const finding = result.findings.find((f) => f.id === 'activity.inactive');
+    expect(finding?.severity).toBe('high');
+  });
+
+  it('reports slowing activity between six months and a year', () => {
+    const result = scoreActivity(
+      buildHealthySnapshot({ activity: { pushedAt: daysAgo(200) } }),
+      NOW,
+    );
+    expect(result.findings.map((f) => f.id)).toContain('activity.slowing');
+    expect(result.findings.map((f) => f.id)).not.toContain('activity.inactive');
+  });
+
+  it('reports having no releases', () => {
+    const result = scoreActivity(
+      buildHealthySnapshot({ activity: { releases: [], tagCount: 0 } }),
+      NOW,
+    );
+    expect(result.findings.map((f) => f.id)).toContain('activity.releases.none');
+  });
+
+  it('keeps contributor count null when GitHub declines to enumerate them', () => {
+    const result = scoreActivity(
+      buildHealthySnapshot({ activity: { contributorCount: null } }),
+      NOW,
+    );
+    const metric = result.metrics.find((m) => m.id === 'activity.contributors.count');
+    expect(metric?.value).toBeNull();
+    expect(metric?.unknownReason).toBe('not_retrieved');
+  });
+});
+
+describe('releaseCadenceScore', () => {
+  const at = (days: number) => new Date(NOW.getTime() - days * 86_400_000);
+
+  it('returns null below three releases, where there is no variation to measure', () => {
+    expect(releaseCadenceScore([])).toBeNull();
+    expect(releaseCadenceScore([at(10)])).toBeNull();
+    expect(releaseCadenceScore([at(10), at(40)])).toBeNull();
+  });
+
+  it('scores perfectly regular intervals at 100', () => {
+    expect(releaseCadenceScore([at(90), at(60), at(30)])).toBe(100);
+  });
+
+  it('scores irregular intervals lower than regular ones', () => {
+    const regular = releaseCadenceScore([at(90), at(60), at(30)]);
+    const irregular = releaseCadenceScore([at(900), at(880), at(30)]);
+    expect(irregular).toBeLessThan(regular ?? 0);
+  });
+
+  it('rates a slow but predictable cadence as well as a fast one', () => {
+    // The point of using a coefficient of variation: consistency is measured
+    // independently of frequency.
+    const slow = releaseCadenceScore([at(1080), at(720), at(360)]);
+    const fast = releaseCadenceScore([at(21), at(14), at(7)]);
+    expect(slow).toBe(fast);
+  });
+
+  it('is not affected by the order dates are supplied in', () => {
+    expect(releaseCadenceScore([at(30), at(90), at(60)])).toBe(
+      releaseCadenceScore([at(90), at(60), at(30)]),
+    );
+  });
+});
+
+describe('purity', () => {
+  it('produces identical results for identical inputs', () => {
+    const snapshot = buildHealthySnapshot();
+    expect(JSON.stringify(scoreActivity(snapshot, NOW))).toBe(
+      JSON.stringify(scoreActivity(snapshot, NOW)),
+    );
+    expect(JSON.stringify(scoreIssues(snapshot))).toBe(
+      JSON.stringify(scoreIssues(snapshot)),
+    );
+  });
+
+  it('does not mutate the snapshot it is given', () => {
+    const snapshot = buildHealthySnapshot();
+    const before = JSON.stringify(snapshot);
+
+    scoreActivity(snapshot, NOW);
+    scoreIssues(snapshot);
+    scorePullRequests(snapshot);
+    scoreCi(snapshot);
+    scoreDocumentation(snapshot);
+    scoreRepository(snapshot);
+    scoreSecurity(snapshot);
+
+    expect(JSON.stringify(snapshot)).toBe(before);
+  });
+});
+
+describe('every category', () => {
+  const snapshot = buildHealthySnapshot();
+  const results = [
+    scoreActivity(snapshot, NOW),
+    scorePullRequests(snapshot),
+    scoreIssues(snapshot),
+    scoreCi(snapshot),
+    scoreDocumentation(snapshot),
+    scoreRepository(snapshot),
+    scoreSecurity(snapshot),
+  ];
+
+  it.each(results.map((r) => [r.key, r]))(
+    '%s discloses a full explanation',
+    (_key, result) => {
+      expect(result.explanation.summary).not.toBe('');
+      expect(result.explanation.formula).not.toBe('');
+      expect(result.explanation.limitations.length).toBeGreaterThan(0);
+    },
+  );
+
+  it.each(results.map((r) => [r.key, r]))(
+    '%s keeps its score within 0–100',
+    (_key, result) => {
+      if (result.score !== null) {
+        expect(result.score).toBeGreaterThanOrEqual(0);
+        expect(result.score).toBeLessThanOrEqual(100);
+      }
+    },
+  );
+
+  it.each(results.map((r) => [r.key, r]))(
+    '%s gives every metric a stable id',
+    (_key, result) => {
+      for (const m of result.metrics) {
+        expect(m.id).toMatch(/^[a-z][a-zA-Z]*(\.[a-zA-Z0-9]+)+$/);
+      }
+    },
+  );
+
+  it('gives every finding an id, recommendation, and confidence', () => {
+    const bare = buildSnapshot({ issues: null, pullRequests: null });
+    const all = [
+      scoreActivity(bare, NOW),
+      scorePullRequests(bare),
+      scoreIssues(bare),
+      scoreCi(bare),
+      scoreDocumentation(bare),
+      scoreRepository(bare),
+      scoreSecurity(bare),
+    ].flatMap((r) => r.findings);
+
+    expect(all.length).toBeGreaterThan(0);
+    for (const finding of all) {
+      expect(finding.id).toMatch(/^[a-zA-Z]+(\.[a-zA-Z0-9]+)+$/);
+      expect(finding.recommendation).not.toBe('');
+      expect(finding.explanation).not.toBe('');
+      expect(['low', 'medium', 'high']).toContain(finding.confidence);
+    }
+  });
+
+  it('keeps finding ids unique within a single analysis', () => {
+    const ids = results.flatMap((r) => r.findings).map((f) => f.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});
+
+describe('allFilesPresent helper', () => {
+  it('describes a fully documented repository', () => {
+    const files = allFilesPresent();
+    expect(files.readme.present).toBe(true);
+    expect(files.lockfiles.length).toBeGreaterThan(0);
+  });
+});

--- a/tests/unit/scoring/overall.test.ts
+++ b/tests/unit/scoring/overall.test.ts
@@ -1,0 +1,355 @@
+import { describe, expect, it } from 'vitest';
+
+import { analyzeSnapshot } from '@/lib/scoring';
+import { scoreOverall, totalDeclaredWeight } from '@/lib/scoring/overall';
+import {
+  CATEGORY_WEIGHTS,
+  MINIMUM_SCORED_CATEGORIES,
+  SCORING_VERSION,
+} from '@/lib/scoring/weights';
+import type { CategoryKey, CategoryScore, Confidence } from '@/types/analysis';
+
+import { NOW, buildHealthySnapshot, buildSnapshot } from '../../support/snapshot-builder';
+
+/** A minimal category score, for exercising combination logic directly. */
+function category(
+  key: CategoryKey,
+  score: number | null,
+  confidence: Confidence = 'high',
+): CategoryScore {
+  return {
+    key,
+    label: key,
+    score,
+    confidence,
+    metrics: [],
+    findings: [],
+    explanation: {
+      summary: '',
+      formula: '',
+      components: [],
+      limitations: [`${key} could not be scored.`],
+    },
+  };
+}
+
+const ALL_KEYS: CategoryKey[] = [
+  'activity',
+  'pullRequests',
+  'issues',
+  'ci',
+  'documentation',
+  'repository',
+  'security',
+];
+
+describe('declared weights', () => {
+  it('sum to 100', () => {
+    expect(totalDeclaredWeight()).toBe(100);
+  });
+
+  it('cover every category exactly once', () => {
+    expect(Object.keys(CATEGORY_WEIGHTS).sort()).toEqual([...ALL_KEYS].sort());
+  });
+});
+
+describe('scoreOverall', () => {
+  it('averages every category when all are scored', () => {
+    const result = scoreOverall(ALL_KEYS.map((key) => category(key, 80)));
+    expect(result.score).toBe(80);
+  });
+
+  it('weights categories by their declared weight', () => {
+    // security is weighted 10, the rest 15. Scoring only security low should
+    // move the total less than scoring an equally-weighted category low.
+    const securityLow = scoreOverall(
+      ALL_KEYS.map((key) => category(key, key === 'security' ? 0 : 100)),
+    );
+    const activityLow = scoreOverall(
+      ALL_KEYS.map((key) => category(key, key === 'activity' ? 0 : 100)),
+    );
+    expect(securityLow.score).toBeGreaterThan(activityLow.score ?? 0);
+  });
+
+  describe('null handling — the rule the product depends on', () => {
+    it('excludes a null category rather than scoring it zero', () => {
+      const result = scoreOverall([
+        category('activity', 90),
+        category('issues', 90),
+        category('ci', 90),
+        category('documentation', null),
+      ]);
+      // With a zero it would be ~67. Excluded, it is 90.
+      expect(result.score).toBe(90);
+    });
+
+    it('never lowers the overall score by adding a null category', () => {
+      // The regression this whole design exists to prevent. Stated as a
+      // property rather than a single case.
+      const withoutNull = scoreOverall([
+        category('activity', 70),
+        category('issues', 80),
+        category('ci', 90),
+      ]);
+
+      for (const key of [
+        'documentation',
+        'repository',
+        'security',
+        'pullRequests',
+      ] as const) {
+        const withNull = scoreOverall([
+          category('activity', 70),
+          category('issues', 80),
+          category('ci', 90),
+          category(key, null),
+        ]);
+        expect(withNull.score).toBe(withoutNull.score);
+      }
+    });
+
+    it('redistributes weight so effective weights still sum to 100', () => {
+      const result = scoreOverall([
+        category('activity', 80),
+        category('issues', 80),
+        category('ci', 80),
+        category('documentation', null),
+        category('security', null),
+      ]);
+
+      // Effective weights are rounded to one decimal for display, so three
+      // equal categories sum to 99.9 rather than exactly 100. The tolerance
+      // allows that rounding but would still catch a redistribution bug.
+      const total = result.contributions.reduce((sum, c) => sum + c.effectiveWeight, 0);
+      expect(total).toBeGreaterThan(99.5);
+      expect(total).toBeLessThanOrEqual(100);
+    });
+
+    it('records why each excluded category was excluded', () => {
+      const result = scoreOverall([
+        category('activity', 80),
+        category('issues', 80),
+        category('ci', 80),
+        category('documentation', null),
+      ]);
+
+      expect(result.excluded).toHaveLength(1);
+      expect(result.excluded[0]?.key).toBe('documentation');
+      expect(result.excluded[0]?.reason).toContain('could not be scored');
+    });
+
+    it('reports both declared and effective weight for each contributor', () => {
+      const result = scoreOverall([
+        category('activity', 80),
+        category('issues', 80),
+        category('ci', 80),
+      ]);
+
+      const activity = result.contributions.find((c) => c.key === 'activity');
+      expect(activity?.declaredWeight).toBe(15);
+      // Three equally weighted categories share the whole score.
+      expect(activity?.effectiveWeight).toBeCloseTo(33.3, 1);
+    });
+  });
+
+  describe(`minimum of ${MINIMUM_SCORED_CATEGORIES} scored categories`, () => {
+    it('returns null with too few categories scored', () => {
+      const result = scoreOverall([
+        category('activity', 90),
+        category('issues', 90),
+        category('ci', null),
+        category('documentation', null),
+      ]);
+      expect(result.score).toBeNull();
+      expect(result.formula).toMatch(/below the minimum/i);
+    });
+
+    it(`returns a number at exactly ${MINIMUM_SCORED_CATEGORIES}`, () => {
+      const result = scoreOverall([
+        category('activity', 90),
+        category('issues', 90),
+        category('ci', 90),
+        category('documentation', null),
+      ]);
+      expect(result.score).toBe(90);
+    });
+
+    it('returns null when nothing was scored at all', () => {
+      expect(scoreOverall(ALL_KEYS.map((key) => category(key, null))).score).toBeNull();
+    });
+
+    it('returns null for an empty category list', () => {
+      expect(scoreOverall([]).score).toBeNull();
+    });
+  });
+
+  describe('confidence', () => {
+    it('is high when everything is scored confidently', () => {
+      expect(scoreOverall(ALL_KEYS.map((key) => category(key, 80))).confidence).toBe(
+        'high',
+      );
+    });
+
+    it('is capped by the least confident contributing category', () => {
+      const result = scoreOverall([
+        ...ALL_KEYS.filter((k) => k !== 'issues').map((key) => category(key, 80)),
+        category('issues', 80, 'low'),
+      ]);
+      expect(result.confidence).toBe('low');
+    });
+
+    it('drops when much of the declared weight could not be scored', () => {
+      const result = scoreOverall([
+        category('activity', 80),
+        category('issues', 80),
+        category('ci', 80),
+        category('documentation', null),
+        category('repository', null),
+        category('security', null),
+        category('pullRequests', null),
+      ]);
+      // 45 of 100 declared weight scored.
+      expect(result.confidence).toBe('low');
+    });
+  });
+
+  it('states the arithmetic it used', () => {
+    const result = scoreOverall([
+      category('activity', 80),
+      category('issues', 60),
+      category('ci', 100),
+    ]);
+    expect(result.formula).toContain('80 ×');
+    expect(result.formula).toContain('60 ×');
+  });
+
+  it('explains that excluded weight was redistributed, not zeroed', () => {
+    const result = scoreOverall([
+      category('activity', 80),
+      category('issues', 80),
+      category('ci', 80),
+      category('documentation', null),
+    ]);
+    expect(result.formula).toMatch(/never counted as zero/i);
+  });
+
+  it('rounds to a whole number', () => {
+    const result = scoreOverall([
+      category('activity', 81),
+      category('issues', 82),
+      category('ci', 84),
+    ]);
+    expect(Number.isInteger(result.score)).toBe(true);
+  });
+});
+
+describe('analyzeSnapshot', () => {
+  const options = { now: NOW, analysisId: 'test-analysis-id' };
+
+  it('produces a complete result for a healthy repository', () => {
+    const result = analyzeSnapshot(buildHealthySnapshot(), options);
+
+    expect(result.scoringVersion).toBe(SCORING_VERSION);
+    expect(result.analysisId).toBe('test-analysis-id');
+    expect(result.categories).toHaveLength(7);
+    expect(result.overall.score).toBeGreaterThan(80);
+  });
+
+  it('records the scoring version on every result', () => {
+    expect(analyzeSnapshot(buildSnapshot(), options).scoringVersion).toMatch(
+      /^\d+\.\d+\.\d+$/,
+    );
+  });
+
+  it('is deterministic', () => {
+    const snapshot = buildHealthySnapshot();
+    expect(JSON.stringify(analyzeSnapshot(snapshot, options))).toBe(
+      JSON.stringify(analyzeSnapshot(snapshot, options)),
+    );
+  });
+
+  it('sorts findings by severity, most severe first', () => {
+    const result = analyzeSnapshot(buildSnapshot(), options);
+    const order = { high: 0, medium: 1, low: 2, info: 3 };
+
+    const severities = result.findings.map((f) => order[f.severity]);
+    const sorted = [...severities].sort((a, b) => a - b);
+    expect(severities).toEqual(sorted);
+  });
+
+  it('still scores a repository with issues and pull requests unavailable', () => {
+    const result = analyzeSnapshot(
+      buildHealthySnapshot({ issues: null, pullRequests: null }),
+      options,
+    );
+
+    expect(result.overall.score).not.toBeNull();
+    expect(result.overall.excluded.map((e) => e.key).sort()).toEqual([
+      'issues',
+      'pullRequests',
+    ]);
+  });
+
+  it('is not penalised for data that could not be collected', () => {
+    const complete = analyzeSnapshot(buildHealthySnapshot(), options);
+    const partial = analyzeSnapshot(
+      buildHealthySnapshot({
+        issues: null,
+        pullRequests: null,
+        ci: { workflowCount: null, recentRunConclusions: [], latestCommitStatus: null },
+      }),
+      options,
+    );
+
+    expect(partial.overall.score).toBeGreaterThanOrEqual(complete.overall.score ?? 0);
+  });
+
+  it('surfaces collection failures as analysis limitations', () => {
+    const result = analyzeSnapshot(
+      buildHealthySnapshot({
+        collection: {
+          requestsMade: 8,
+          failures: [{ resource: 'actions/runs', reason: 'forbidden' }],
+          rateLimitRemaining: 100,
+        },
+      }),
+      options,
+    );
+
+    expect(result.limitations.join(' ')).toContain('actions/runs');
+    expect(result.limitations.join(' ')).toMatch(/excluded rather than assumed/i);
+  });
+
+  it('notes when the repository is a fork', () => {
+    const result = analyzeSnapshot(
+      buildHealthySnapshot({ identity: { isFork: true } }),
+      options,
+    );
+    expect(result.limitations.join(' ')).toMatch(/fork/i);
+  });
+
+  it('scores an empty repository low but does not crash', () => {
+    const result = analyzeSnapshot(
+      buildSnapshot({
+        issues: null,
+        pullRequests: null,
+        activity: {
+          releases: [],
+          tagCount: 0,
+          weeklyCommits: null,
+          contributorCount: null,
+        },
+        ci: { workflowCount: 0, recentRunConclusions: [], latestCommitStatus: 'none' },
+      }),
+      options,
+    );
+
+    expect(result.overall.score).toBeLessThan(30);
+    expect(result.findings.length).toBeGreaterThan(0);
+  });
+
+  it('serializes to JSON without loss, so results can be cached', () => {
+    const result = analyzeSnapshot(buildHealthySnapshot(), options);
+    expect(JSON.parse(JSON.stringify(result))).toEqual(result);
+  });
+});


### PR DESCRIPTION
## Summary

Seven pure category scorers plus the overall engine that combines them. This is the correctness core of the product.

Closes #11, #12, #13, #14, #15, #16, #17, #18

## Why

Every function here takes `(snapshot, now)` and returns a result — no I/O, no clock access, no randomness. That is what makes results reproducible, every threshold directly testable, and a stored analysis interpretable years later against the `scoringVersion` that produced it.

## The overall engine

This is the load-bearing part, and the place the null-preservation rule either holds or quietly breaks.

A category that returned `null` is **excluded**, and its declared weight is redistributed across the categories that did produce a score. Asserted as a property rather than a single case:

```ts
it('never lowers the overall score by adding a null category', () => { … })
```

If nulls were scored as zero instead, a repository with issues disabled would be punished for a setting, and one whose commit statistics GitHub had not computed would be punished for GitHub's queue.

Below three scored categories, the overall score is `null` rather than an average — averaging two categories and calling it engineering health implies far more coverage than the evidence supports.

## Category decisions worth reviewing

| Decision | Reasoning |
| --- | --- |
| Archived repos aren't scored as neglected | Archiving is a deliberate "this is finished", not a failure to maintain. Recency components are excluded and the archival is reported instead. |
| Unavailable CI → `null`; absent CI → `0` | Different observations. "We couldn't read it" and "there isn't any" must not collapse together. |
| Cancelled/skipped runs excluded from success rate | A cancelled run is usually a superseded one. Counting it as a failure would penalize exactly the projects that cancel outdated runs to save CI minutes. |
| Merge velocity uses the **median** | One PR left open four years then merged makes the mean 251 days where the median is 2. Tested directly. |
| Release cadence uses coefficient of variation | Measures consistency independent of frequency, so a predictable six-monthly cadence scores the same as a predictable weekly one. `null` below three releases, where there is no variation to measure. |
| Branch protection stays `null` on 403 | Reading it needs admin access. "Unable to verify" must never render as "not protected". |

## Two constraints enforced by test, not convention

**Findings state observations, never intent.** RepoSignal cannot observe why an issue is open, so it doesn't guess:

```ts
expect(text).not.toMatch(/ignor(e|ing|ed)/i);
expect(text).not.toMatch(/neglect/i);
```

**Security Hygiene never claims a repository is secure.** The test collects every user-facing string in the module — label, summary, limitations, component rules, finding titles and explanations — and asserts none of them says so. A perfect score means four practices were observed, and the module has to keep saying exactly that.

## Testing

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test` — 348 passing
- [x] `npm run build`

```
File          | % Stmts | % Branch | % Funcs | % Lines
--------------|---------|----------|---------|--------
All files     |   94.03 |    85.26 |   91.66 |   95.05
 scoring      |   92.67 |    83.59 |   98.27 |   94.28
 normalize    |   98.56 |    91.76 |   97.43 |   99.15
```

Every threshold is tested at its boundary and one unit either side. Every category has an explicit test that insufficient data yields `null` rather than `0`.

## Risks

The weights are a judgment call and the module comment says so plainly: six categories are equal at 15 because there is no evidence any one dimension predicts another better, and asserting otherwise would be fabricated precision. Security Hygiene is 10 because it observes the fewest independent signals. These are the most arguable numbers in the project, which is why every one of them is disclosed in the UI rather than buried.

Thresholds (180-day stale, 90-day long-lived PR, 300-byte README stub) are defensible but not derived from data. Each carries its reasoning in a comment, and changing one requires a `SCORING_VERSION` bump.

## Checklist

- [x] Scope matches the linked issues
- [x] Tests cover the new behavior, including null and partial-data paths
- [x] Scoring rules are versioned at `SCORING_VERSION = '1.0.0'`; `docs/SCORING.md` lands with #29
- [x] No secrets, tokens, or personal data added to the repository or logs
- [x] Documentation updated where behavior changed (CHANGELOG)