### PR TITLE
feat: add persistence, caching, and observability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ analysis records the `scoringVersion` it was produced under.
 
 ### Added
 
+- Analysis orchestration with a 15-minute cache freshness window, in-flight
+  request deduplication, and invalidation when `scoringVersion` changes
+- Persistence: a Prisma/PostgreSQL store keyed on GitHub's immutable numeric
+  repository id, with an in-memory fallback so the application runs without a
+  database
+- Structured JSON logging correlated by analysis id, and per-client rate
+  limiting
 - Scoring engine (`scoringVersion` 1.0.0): seven pure category scorers —
   activity, pull requests, issues, CI, documentation, repository hygiene, and
   security hygiene — plus the overall engine that renormalizes declared weights

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,13 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
+        "@prisma/adapter-pg": "^7.9.1",
         "@prisma/client": "^7.9.1",
         "next": "16.3.1",
+        "pg": "^8.23.0",
         "react": "19.2.8",
         "react-dom": "19.2.8",
+        "server-only": "^0.0.1",
         "zod": "^4.4.3"
       },
       "devDependencies": {
@@ -22,6 +25,7 @@
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.4",
         "@types/node": "^26.2.0",
+        "@types/pg": "^8.23.1",
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "@vitejs/plugin-react": "^6.0.5",
@@ -2222,6 +2226,18 @@
         "node": ">=20"
       }
     },
+    "node_modules/@prisma/adapter-pg": {
+      "version": "7.9.1",
+      "resolved": "https://registry.npmjs.org/@prisma/adapter-pg/-/adapter-pg-7.9.1.tgz",
+      "integrity": "sha512-Ho2RK1KanQxLNSC0sR5bpiiVep10sWPLXCcxK+KXfI/Q69TMRbiafSvLPv3V9snimX72rMCqGlyJ4sBO4lKTAw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/driver-adapter-utils": "7.9.1",
+        "@types/pg": "^8.16.0",
+        "pg": "^8.16.3",
+        "postgres-array": "3.0.4"
+      }
+    },
     "node_modules/@prisma/client": {
       "version": "7.9.1",
       "resolved": "https://registry.npmjs.org/@prisma/client/-/client-7.9.1.tgz",
@@ -2269,7 +2285,6 @@
       "version": "7.9.1",
       "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-7.9.1.tgz",
       "integrity": "sha512-/cpVZ4itxtcgB8GHBvZtcmuEjq+lWsLrRJxFMbwZrT1RIdtuKmUm7PPGo/wzfbYpBrk+9WmmBE8CHJw2rybKDQ==",
-      "devOptional": true,
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/dev": {
@@ -2302,6 +2317,15 @@
       "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/@prisma/driver-adapter-utils": {
+      "version": "7.9.1",
+      "resolved": "https://registry.npmjs.org/@prisma/driver-adapter-utils/-/driver-adapter-utils-7.9.1.tgz",
+      "integrity": "sha512-vmHehG7nn/heW32DXXpp13DxxAxVVe6n250oEt3dOL2E/4bt3olktKZN0mzSuxMMronyMSkbeW2uCOn3F4g8RQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "7.9.1"
+      }
     },
     "node_modules/@prisma/engines": {
       "version": "7.9.1",
@@ -3411,10 +3435,20 @@
       "version": "26.2.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-26.2.0.tgz",
       "integrity": "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~8.3.0"
+      }
+    },
+    "node_modules/@types/pg": {
+      "version": "8.23.1",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.23.1.tgz",
+      "integrity": "sha512-fKVHpikPdg4GKks3JuLEhvwSyvwzF23hnabPy6DD8ljVbC7+6J5dQzdv4arV6jqq57djnMgs1HKBxX4P8aBI3A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
       }
     },
     "node_modules/@types/react": {
@@ -8860,6 +8894,104 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/pg": {
+      "version": "8.23.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.23.0.tgz",
+      "integrity": "sha512-Ip2EQCngowJLGOfCwkFhPXU7/ljlhn6Rxlmy4XYfL2Y+vyRM59+8uR2xqRWKdYmbXmxCFOAmKxBuSUCdF34qLg==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.14.0",
+        "pg-pool": "^3.14.0",
+        "pg-protocol": "^1.16.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.4.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.4.0.tgz",
+      "integrity": "sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.14.0.tgz",
+      "integrity": "sha512-XwWDGcLRGCXAR8F/AM5bG7Q+A3Wm2s6QeEjlOKZLlH3UYcguiqCWKyWXVag5TLTIjR7oOJUY8kcADaZgWPyLeg==",
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.14.0.tgz",
+      "integrity": "sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.16.0.tgz",
+      "integrity": "sha512-sILXutLVjCLjcDuOmvhX5e2Z4cS5qG/6Bu3VkpFwdf/633ElGLpEh9bgmuI5I4sqKqkifQiGyiCcx1HdtrK7tg==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pg-types/node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -8974,6 +9106,45 @@
       "funding": {
         "type": "individual",
         "url": "https://github.com/sponsors/porsager"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-3.0.4.tgz",
+      "integrity": "sha512-nAUSGfSDGOaOAEGwqsRY27GPOea7CNipJPOA7lPbdEpx5Kg3qzdP0AaWC5MlhTWV9s4hFX39nomVZ+C4tnGOJQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/prelude-ls": {
@@ -9639,6 +9810,12 @@
       "integrity": "sha512-hr3Wtp/GZIc/6DAGPDcV4/9WoZhjrkXsi5B/07QgX8tsdc6ilr7BFM6PM6rbdAX1kFSDYeZGLipIZZKyQP0O5Q==",
       "devOptional": true
     },
+    "node_modules/server-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/server-only/-/server-only-0.0.1.tgz",
+      "integrity": "sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==",
+      "license": "MIT"
+    },
     "node_modules/set-cookie-parser": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-3.1.2.tgz",
@@ -9884,6 +10061,15 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
       }
     },
     "node_modules/sqlstring": {
@@ -10590,7 +10776,6 @@
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
       "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unrs-resolver": {
@@ -11381,6 +11566,15 @@
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -25,10 +25,13 @@
     "db:studio": "prisma studio"
   },
   "dependencies": {
+    "@prisma/adapter-pg": "^7.9.1",
     "@prisma/client": "^7.9.1",
     "next": "16.3.1",
+    "pg": "^8.23.0",
     "react": "19.2.8",
     "react-dom": "19.2.8",
+    "server-only": "^0.0.1",
     "zod": "^4.4.3"
   },
   "devDependencies": {
@@ -38,6 +41,7 @@
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.4",
     "@types/node": "^26.2.0",
+    "@types/pg": "^8.23.1",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "@vitejs/plugin-react": "^6.0.5",

--- a/prisma.config.ts
+++ b/prisma.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'prisma/config';
+
+/**
+ * Prisma 7 moved the connection URL out of `schema.prisma`. Migration and
+ * introspection commands read it from here; the runtime client gets its
+ * connection through a driver adapter instead (see `src/lib/store/prisma.ts`).
+ *
+ * The datasource is only declared when `DATABASE_URL` is actually set.
+ * `prisma generate` needs no database, and RepoSignal runs without one — using
+ * Prisma's `env()` helper here would throw in both cases, since it treats a
+ * missing variable as fatal rather than absent.
+ */
+const databaseUrl = process.env.DATABASE_URL;
+
+export default defineConfig({
+  schema: 'prisma/schema.prisma',
+  ...(databaseUrl === undefined || databaseUrl === ''
+    ? {}
+    : { datasource: { url: databaseUrl } }),
+});

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,63 @@
+// RepoSignal data model.
+//
+// Two decisions drive this schema:
+//
+// 1. Repository identity is GitHub's immutable numeric id, not `owner/name`.
+//    Repositories get renamed and transferred; keying on the mutable name
+//    would silently fork one project's history into two records.
+//
+// 2. Analyses are append-only. Re-analysis inserts a new row rather than
+//    updating one, so a cache read is "the most recent row, if fresh enough",
+//    and historical score tracking needs no schema change to add later.
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+
+}
+
+model Repository {
+  /// GitHub's numeric id. The stable identity across renames and transfers.
+  githubId  BigInt     @id
+  /// Current owner and name. Mutable — a lookup key, not an identity.
+  owner     String
+  name      String
+  fullName  String
+  firstSeen DateTime   @default(now())
+  lastSeen  DateTime   @updatedAt
+  analyses  Analysis[]
+
+  /// Not unique: a rename can leave a stale row pointing at the same name
+  /// until the new owner is analyzed, and failing that write would be worse
+  /// than briefly holding two rows.
+  @@index([fullName])
+  @@map("repositories")
+}
+
+model Analysis {
+  id           String     @id @default(uuid())
+  repository   Repository @relation(fields: [repositoryId], references: [githubId], onDelete: Cascade)
+  repositoryId BigInt
+
+  /// Overall score, nullable because "not enough data to score" is a real
+  /// outcome that must never be stored as zero.
+  overallScore Int?
+  /// The algorithm version that produced this result, so a stored analysis
+  /// stays interpretable after the scoring rules change.
+  scoringVersion String
+
+  /// The full AnalysisResult and the RepositorySnapshot it was derived from.
+  /// Stored whole so a cached analysis can be re-rendered without re-scoring,
+  /// and so a historical result can be re-examined against new rules.
+  result   Json
+  snapshot Json
+
+  createdAt DateTime @default(now())
+
+  /// The cache read: most recent analysis for a repository.
+  @@index([repositoryId, createdAt])
+  @@map("analyses")
+}

--- a/src/lib/analysis/container.ts
+++ b/src/lib/analysis/container.ts
@@ -1,0 +1,73 @@
+import 'server-only';
+
+import { logger } from '@/lib/logging/logger';
+import { RateLimiter } from '@/lib/rate-limit';
+import { MemoryAnalysisStore } from '@/lib/store/memory-store';
+import type { AnalysisStore } from '@/lib/store/types';
+
+import { AnalysisService } from './service';
+
+/**
+ * Application wiring.
+ *
+ * `server-only` at the top makes importing this from a client component a build
+ * error rather than a runtime surprise, which is what keeps the GitHub token
+ * out of the browser bundle.
+ *
+ * The store is chosen at startup: Postgres when `DATABASE_URL` is set,
+ * in-memory otherwise. RepoSignal works either way — without a database,
+ * cached analyses simply do not survive a restart.
+ */
+
+let store: AnalysisStore | undefined;
+let service: AnalysisService | undefined;
+
+async function resolveStore(): Promise<AnalysisStore> {
+  if (store) return store;
+
+  const databaseUrl = process.env.DATABASE_URL;
+
+  if (databaseUrl === undefined || databaseUrl === '') {
+    logger.warn('store_unavailable', {
+      reason: 'no_database_url',
+      detail: 'Falling back to the in-memory store; analyses will not survive a restart.',
+    });
+    store = new MemoryAnalysisStore();
+    return store;
+  }
+
+  // Imported lazily so a deployment without a database never loads the Prisma
+  // client or the pg driver at all.
+  const { PrismaAnalysisStore, getPrismaClient } =
+    await import('@/lib/store/prisma-store');
+
+  store = new PrismaAnalysisStore(getPrismaClient(databaseUrl));
+  return store;
+}
+
+export async function getAnalysisService(): Promise<AnalysisService> {
+  if (service) return service;
+
+  const freshness = Number.parseInt(process.env.ANALYSIS_FRESHNESS_MINUTES ?? '', 10);
+  const budget = Number.parseInt(process.env.GITHUB_REQUEST_BUDGET ?? '', 10);
+
+  service = new AnalysisService({
+    store: await resolveStore(),
+    logger,
+    ...(Number.isFinite(freshness) && freshness > 0
+      ? { freshnessMinutes: freshness }
+      : {}),
+    ...(Number.isFinite(budget) && budget > 0 ? { requestBudget: budget } : {}),
+  });
+
+  return service;
+}
+
+/**
+ * Per-client limits.
+ *
+ * Analysis is capped generously because most requests are cache hits. Refresh
+ * is capped tightly because every one of them spends GitHub rate limit.
+ */
+export const analysisRateLimiter = new RateLimiter(30, 60_000);
+export const refreshRateLimiter = new RateLimiter(5, 300_000);

--- a/src/lib/analysis/service.ts
+++ b/src/lib/analysis/service.ts
@@ -1,0 +1,211 @@
+import { GitHubClient } from '@/lib/github/client';
+import { collectSnapshot } from '@/lib/github/collector';
+import { GitHubError, isRateLimitError } from '@/lib/github/errors';
+import { RequestBudget } from '@/lib/github/request-budget';
+import type { Logger } from '@/lib/logging/logger';
+import { analyzeSnapshot } from '@/lib/scoring';
+import { SCORING_VERSION } from '@/lib/scoring/weights';
+import type { AnalysisStore } from '@/lib/store/types';
+import {
+  formatRepositoryReference,
+  type RepositoryReference,
+} from '@/lib/validation/repository-reference';
+import type { AnalysisResult } from '@/types/analysis';
+
+/**
+ * Orchestrates one analysis: cache lookup, collection, scoring, persistence.
+ *
+ * Three policies live here rather than in the UI, so every entry point gets
+ * them consistently:
+ *
+ * - **Freshness.** A cached analysis younger than the window is served
+ *   directly, without touching GitHub.
+ * - **Deduplication.** Concurrent requests for the same repository share one
+ *   in-flight promise, so ten simultaneous visitors cost one analysis.
+ * - **Version invalidation.** A cached analysis produced under a different
+ *   `scoringVersion` is not served, because its numbers mean something else.
+ */
+
+export const DEFAULT_FRESHNESS_MINUTES = 15;
+
+export interface AnalysisOutcome {
+  result: AnalysisResult;
+  /** Whether this came from cache, and how old it was. */
+  cached: boolean;
+  ageSeconds: number;
+}
+
+export interface AnalysisServiceOptions {
+  store: AnalysisStore;
+  logger: Logger;
+  freshnessMinutes?: number;
+  requestBudget?: number;
+  /** Injected so tests control time; defaults to the wall clock. */
+  now?: () => Date;
+  /** Injected so tests control ids; defaults to a random UUID. */
+  generateId?: () => string;
+  /** Injected for tests. */
+  createClient?: (budget: RequestBudget) => GitHubClient;
+}
+
+export class AnalysisService {
+  #inFlight = new Map<string, Promise<AnalysisOutcome>>();
+
+  constructor(private readonly options: AnalysisServiceOptions) {}
+
+  #now(): Date {
+    return this.options.now?.() ?? new Date();
+  }
+
+  #freshnessMs(): number {
+    return (this.options.freshnessMinutes ?? DEFAULT_FRESHNESS_MINUTES) * 60_000;
+  }
+
+  /**
+   * Analyzes a repository, serving a fresh cached result when one exists.
+   *
+   * `forceRefresh` bypasses the cache. It is exposed so a user can ask for
+   * current data after acting on a finding, and is rate limited separately by
+   * the caller.
+   */
+  async analyze(
+    reference: RepositoryReference,
+    options: { forceRefresh?: boolean } = {},
+  ): Promise<AnalysisOutcome> {
+    const fullName = formatRepositoryReference(reference);
+    const key = `${fullName.toLowerCase()}:${options.forceRefresh === true}`;
+
+    // Deduplication: ten concurrent visitors to a popular repository should
+    // cost one analysis, not ten.
+    const existing = this.#inFlight.get(key);
+    if (existing) return existing;
+
+    const work = this.#analyzeUncached(reference, fullName, options).finally(() => {
+      this.#inFlight.delete(key);
+    });
+
+    this.#inFlight.set(key, work);
+    return work;
+  }
+
+  async #analyzeUncached(
+    reference: RepositoryReference,
+    fullName: string,
+    options: { forceRefresh?: boolean },
+  ): Promise<AnalysisOutcome> {
+    const { store, logger } = this.options;
+    const startedAt = Date.now();
+
+    if (options.forceRefresh !== true) {
+      const cached = await this.#readCache(fullName);
+      if (cached !== null) return cached;
+    }
+
+    const analysisId = this.options.generateId?.() ?? crypto.randomUUID();
+    logger.info('analysis_started', { analysisId, repository: fullName });
+
+    const budget = new RequestBudget(this.options.requestBudget ?? 40);
+    const client = this.options.createClient?.(budget) ?? new GitHubClient({ budget });
+
+    try {
+      const now = this.#now();
+      const snapshot = await collectSnapshot(client, reference, now);
+      const result = analyzeSnapshot(snapshot, { now, analysisId });
+
+      // Persistence failure must not fail an analysis that already succeeded.
+      // The user gets their result; the cache simply misses next time.
+      try {
+        await store.save({ result, snapshot, createdAt: now });
+      } catch (error) {
+        logger.warn('store_unavailable', {
+          analysisId,
+          repository: fullName,
+          reason: error instanceof Error ? error.name : 'unknown',
+        });
+      }
+
+      logger.info('analysis_completed', {
+        analysisId,
+        repository: fullName,
+        score: result.overall.score,
+        durationMs: Date.now() - startedAt,
+        requestsMade: snapshot.collection.requestsMade,
+        rateLimitRemaining: snapshot.collection.rateLimitRemaining,
+        scoringVersion: result.scoringVersion,
+      });
+
+      return { result, cached: false, ageSeconds: 0 };
+    } catch (error) {
+      if (isRateLimitError(error)) {
+        logger.warn('rate_limit_reached', {
+          analysisId,
+          repository: fullName,
+          resetAt: error.resetAt?.toISOString() ?? null,
+          isSecondary: error.isSecondary,
+        });
+      } else {
+        logger.error('analysis_failed', {
+          analysisId,
+          repository: fullName,
+          reason: error instanceof GitHubError ? error.kind : 'unexpected',
+          durationMs: Date.now() - startedAt,
+        });
+      }
+
+      throw error;
+    }
+  }
+
+  async #readCache(fullName: string): Promise<AnalysisOutcome | null> {
+    const { store, logger } = this.options;
+
+    let githubId: number | null;
+    try {
+      githubId = await store.findIdByFullName(fullName);
+    } catch {
+      // An unreachable store is a cache miss, not an analysis failure.
+      return null;
+    }
+
+    if (githubId === null) {
+      logger.info('cache_miss', { repository: fullName });
+      return null;
+    }
+
+    const stored = await store.findLatest(githubId).catch(() => null);
+    if (stored === null) {
+      logger.info('cache_miss', { repository: fullName });
+      return null;
+    }
+
+    // A result produced under different rules is not a cache hit — its numbers
+    // mean something else, and serving it would misrepresent them as current.
+    if (stored.result.scoringVersion !== SCORING_VERSION) {
+      logger.info('cache_miss', {
+        repository: fullName,
+        reason: 'scoring_version_changed',
+        scoringVersion: stored.result.scoringVersion,
+      });
+      return null;
+    }
+
+    const ageMs = this.#now().getTime() - stored.createdAt.getTime();
+    if (ageMs > this.#freshnessMs() || ageMs < 0) {
+      logger.info('cache_miss', {
+        repository: fullName,
+        reason: 'stale',
+        ageSeconds: Math.round(ageMs / 1000),
+      });
+      return null;
+    }
+
+    const ageSeconds = Math.max(0, Math.round(ageMs / 1000));
+    logger.info('cache_hit', {
+      analysisId: stored.result.analysisId,
+      repository: fullName,
+      ageSeconds,
+    });
+
+    return { result: stored.result, cached: true, ageSeconds };
+  }
+}

--- a/src/lib/logging/logger.ts
+++ b/src/lib/logging/logger.ts
@@ -1,0 +1,111 @@
+/**
+ * Structured server logging.
+ *
+ * One JSON object per line to stdout, correlated by `analysisId`. Line-oriented
+ * JSON is what makes logs greppable locally and ingestible by any hosted log
+ * service without an agent.
+ *
+ * **Nothing sensitive is ever logged.** There is no code path that writes a
+ * token, an authorization header, or a full API payload, and a test asserts it.
+ */
+
+export type LogLevel = 'debug' | 'info' | 'warn' | 'error';
+
+export type LogEvent =
+  | 'analysis_started'
+  | 'analysis_completed'
+  | 'analysis_failed'
+  | 'github_request_failed'
+  | 'rate_limit_reached'
+  | 'cache_hit'
+  | 'cache_miss'
+  | 'store_unavailable';
+
+/**
+ * Named fields explicitly admit `undefined` rather than only being optional.
+ *
+ * Callers routinely spread objects whose fields may be absent, and the logger
+ * already drops undefined values before serializing. Forbidding `undefined` at
+ * the type level while handling it at runtime would just force callers into
+ * conditional spreads for no benefit.
+ */
+export interface LogFields {
+  analysisId?: string | undefined;
+  repository?: string | undefined;
+  durationMs?: number | undefined;
+  score?: number | null | undefined;
+  reason?: string | undefined;
+  requestsMade?: number | undefined;
+  rateLimitRemaining?: number | null | undefined;
+  scoringVersion?: string | undefined;
+  ageSeconds?: number | undefined;
+  [key: string]: string | number | boolean | null | undefined;
+}
+
+export interface LogRecord extends LogFields {
+  level: LogLevel;
+  event: LogEvent;
+  timestamp: string;
+}
+
+/**
+ * Keys that must never appear in a log line.
+ *
+ * The logger drops them defensively. The real protection is that no caller
+ * passes them, but a defensive drop means a future careless caller degrades to
+ * a missing field rather than a leaked credential.
+ */
+const FORBIDDEN_KEYS = new Set([
+  'token',
+  'githubToken',
+  'authorization',
+  'auth',
+  'password',
+  'secret',
+  'apiKey',
+  'accessToken',
+  'cookie',
+]);
+
+export interface Logger {
+  log(level: LogLevel, event: LogEvent, fields?: LogFields): void;
+  info(event: LogEvent, fields?: LogFields): void;
+  warn(event: LogEvent, fields?: LogFields): void;
+  error(event: LogEvent, fields?: LogFields): void;
+}
+
+export function createLogger(
+  options: { write?: (line: string) => void; now?: () => Date } = {},
+): Logger {
+  const write = options.write ?? ((line: string) => console.warn(line));
+  const now = options.now ?? (() => new Date());
+
+  function log(level: LogLevel, event: LogEvent, fields: LogFields = {}): void {
+    const safe: LogFields = {};
+
+    for (const [key, value] of Object.entries(fields)) {
+      if (FORBIDDEN_KEYS.has(key)) continue;
+      if (value === undefined) continue;
+      safe[key] = value;
+    }
+
+    const record: LogRecord = {
+      level,
+      event,
+      timestamp: now().toISOString(),
+      ...safe,
+    };
+
+    write(JSON.stringify(record));
+  }
+
+  return {
+    log,
+    info: (event, fields) => log('info', event, fields),
+    warn: (event, fields) => log('warn', event, fields),
+    error: (event, fields) => log('error', event, fields),
+  };
+}
+
+/** The application logger. Tests build their own with an injected writer. */
+export const logger = createLogger();

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -1,0 +1,66 @@
+/**
+ * Fixed-window rate limiter, in memory.
+ *
+ * Deliberately simple. A distributed limiter needs shared state, and RepoSignal
+ * has no requirement that justifies adding Redis — on a single instance this is
+ * exact, and across several it limits per instance, which is still a meaningful
+ * bound on how fast one client can spend the GitHub rate limit.
+ *
+ * The tradeoff is written down rather than hidden, because someone scaling this
+ * horizontally needs to know the guarantee weakens.
+ */
+export interface RateLimitResult {
+  allowed: boolean;
+  remaining: number;
+  /** Seconds until the window resets. Sent as `Retry-After`. */
+  retryAfterSeconds: number;
+}
+
+export class RateLimiter {
+  #hits = new Map<string, { count: number; resetAt: number }>();
+
+  constructor(
+    private readonly limit: number,
+    private readonly windowMs: number,
+    private readonly now: () => number = Date.now,
+  ) {}
+
+  check(key: string): RateLimitResult {
+    const currentTime = this.now();
+    const entry = this.#hits.get(key);
+
+    if (entry === undefined || currentTime >= entry.resetAt) {
+      this.#hits.set(key, { count: 1, resetAt: currentTime + this.windowMs });
+      this.#evictExpired(currentTime);
+      return {
+        allowed: true,
+        remaining: this.limit - 1,
+        retryAfterSeconds: Math.ceil(this.windowMs / 1000),
+      };
+    }
+
+    const retryAfterSeconds = Math.max(
+      1,
+      Math.ceil((entry.resetAt - currentTime) / 1000),
+    );
+
+    if (entry.count >= this.limit) {
+      return { allowed: false, remaining: 0, retryAfterSeconds };
+    }
+
+    entry.count += 1;
+    return {
+      allowed: true,
+      remaining: this.limit - entry.count,
+      retryAfterSeconds,
+    };
+  }
+
+  /** Keeps the map from growing without bound on a long-running process. */
+  #evictExpired(currentTime: number): void {
+    if (this.#hits.size < 1000) return;
+    for (const [key, entry] of this.#hits) {
+      if (currentTime >= entry.resetAt) this.#hits.delete(key);
+    }
+  }
+}

--- a/src/lib/store/memory-store.ts
+++ b/src/lib/store/memory-store.ts
@@ -1,0 +1,54 @@
+import type { AnalysisStore, StoredAnalysis } from './types';
+
+/**
+ * In-memory analysis store.
+ *
+ * Used by tests, and as the production fallback when `DATABASE_URL` is not
+ * configured. That fallback is deliberate: RepoSignal is useful without a
+ * database — analyses simply do not survive a restart — and requiring one to
+ * run the app would make the project harder to try than it needs to be.
+ *
+ * Entries are capped so a long-running process cannot grow without bound.
+ */
+export class MemoryAnalysisStore implements AnalysisStore {
+  #byRepository = new Map<number, StoredAnalysis>();
+  #idsByFullName = new Map<string, number>();
+  #insertionOrder: number[] = [];
+
+  constructor(private readonly maxEntries = 200) {}
+
+  async findLatest(githubId: number): Promise<StoredAnalysis | null> {
+    return this.#byRepository.get(githubId) ?? null;
+  }
+
+  async findIdByFullName(fullName: string): Promise<number | null> {
+    return this.#idsByFullName.get(fullName.toLowerCase()) ?? null;
+  }
+
+  async save(entry: StoredAnalysis): Promise<void> {
+    const githubId = entry.result.repository.githubId;
+
+    if (!this.#byRepository.has(githubId)) {
+      this.#insertionOrder.push(githubId);
+    }
+
+    this.#byRepository.set(githubId, entry);
+    this.#idsByFullName.set(entry.result.repository.fullName.toLowerCase(), githubId);
+
+    while (this.#insertionOrder.length > this.maxEntries) {
+      const oldest = this.#insertionOrder.shift();
+      if (oldest === undefined) break;
+
+      const evicted = this.#byRepository.get(oldest);
+      this.#byRepository.delete(oldest);
+      if (evicted) {
+        this.#idsByFullName.delete(evicted.result.repository.fullName.toLowerCase());
+      }
+    }
+  }
+
+  /** Test helper. */
+  get size(): number {
+    return this.#byRepository.size;
+  }
+}

--- a/src/lib/store/prisma-store.ts
+++ b/src/lib/store/prisma-store.ts
@@ -1,0 +1,96 @@
+import { PrismaPg } from '@prisma/adapter-pg';
+import { PrismaClient } from '@prisma/client';
+
+import type { AnalysisResult } from '@/types/analysis';
+import type { RepositorySnapshot } from '@/types/snapshot';
+
+import type { AnalysisStore, StoredAnalysis } from './types';
+
+/**
+ * Postgres-backed analysis store.
+ *
+ * Prisma 7 requires a driver adapter rather than a connection string in the
+ * schema, so the client is constructed here with `PrismaPg`.
+ *
+ * The client is memoized on `globalThis` because Next.js recreates modules on
+ * every hot reload in development, and a fresh connection pool per reload
+ * exhausts Postgres connections within a few edits.
+ */
+const globalForPrisma = globalThis as unknown as { prisma?: PrismaClient };
+
+export function getPrismaClient(databaseUrl: string): PrismaClient {
+  if (globalForPrisma.prisma) return globalForPrisma.prisma;
+
+  const client = new PrismaClient({
+    adapter: new PrismaPg({ connectionString: databaseUrl }),
+  });
+
+  if (process.env.NODE_ENV !== 'production') {
+    globalForPrisma.prisma = client;
+  }
+
+  return client;
+}
+
+export class PrismaAnalysisStore implements AnalysisStore {
+  constructor(private readonly prisma: PrismaClient) {}
+
+  async findLatest(githubId: number): Promise<StoredAnalysis | null> {
+    const row = await this.prisma.analysis.findFirst({
+      where: { repositoryId: BigInt(githubId) },
+      orderBy: { createdAt: 'desc' },
+    });
+
+    if (row === null) return null;
+
+    return {
+      result: row.result as unknown as AnalysisResult,
+      snapshot: row.snapshot as unknown as RepositorySnapshot,
+      createdAt: row.createdAt,
+    };
+  }
+
+  async findIdByFullName(fullName: string): Promise<number | null> {
+    const row = await this.prisma.repository.findFirst({
+      where: { fullName },
+      orderBy: { lastSeen: 'desc' },
+    });
+
+    return row === null ? null : Number(row.githubId);
+  }
+
+  async save(entry: StoredAnalysis): Promise<void> {
+    const identity = entry.result.repository;
+    const githubId = BigInt(identity.githubId);
+
+    // Upsert the repository, then append the analysis. Both in one transaction
+    // so a crash between them cannot leave an analysis without its repository.
+    await this.prisma.$transaction([
+      this.prisma.repository.upsert({
+        where: { githubId },
+        create: {
+          githubId,
+          owner: identity.owner,
+          name: identity.name,
+          fullName: identity.fullName,
+        },
+        // A rename shows up here: the identity is unchanged, the name is not.
+        update: {
+          owner: identity.owner,
+          name: identity.name,
+          fullName: identity.fullName,
+        },
+      }),
+      this.prisma.analysis.create({
+        data: {
+          repositoryId: githubId,
+          overallScore: entry.result.overall.score,
+          scoringVersion: entry.result.scoringVersion,
+          result: JSON.parse(JSON.stringify(entry.result)),
+          snapshot: JSON.parse(JSON.stringify(entry.snapshot)),
+          createdAt: entry.createdAt,
+        },
+      }),
+    ]);
+  }
+}

--- a/src/lib/store/types.ts
+++ b/src/lib/store/types.ts
@@ -1,0 +1,36 @@
+import type { AnalysisResult } from '@/types/analysis';
+import type { RepositorySnapshot } from '@/types/snapshot';
+
+/**
+ * Persistence boundary for analyses.
+ *
+ * An interface rather than direct Prisma calls, for one concrete reason: the
+ * application must run without a database. Deployments without `DATABASE_URL`
+ * fall back to the in-memory implementation, tests use it too, and CI never
+ * needs a Postgres service container.
+ *
+ * Analyses are append-only. Re-analysis inserts a new record rather than
+ * mutating one, which gives historical score tracking for free later and makes
+ * a cache read a straightforward "most recent, if fresh enough" query.
+ */
+export interface StoredAnalysis {
+  result: AnalysisResult;
+  snapshot: RepositorySnapshot;
+  createdAt: Date;
+}
+
+export interface AnalysisStore {
+  /**
+   * The most recent analysis for a repository, or `null`.
+   *
+   * Looked up by GitHub's immutable numeric id, not `owner/name`, so a renamed
+   * or transferred repository keeps its history instead of silently forking
+   * into two records.
+   */
+  findLatest(githubId: number): Promise<StoredAnalysis | null>;
+
+  /** Resolves `owner/name` to a GitHub id previously seen, if any. */
+  findIdByFullName(fullName: string): Promise<number | null>;
+
+  save(entry: StoredAnalysis): Promise<void>;
+}

--- a/tests/unit/analysis/service.test.ts
+++ b/tests/unit/analysis/service.test.ts
@@ -1,0 +1,346 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { AnalysisService } from '@/lib/analysis/service';
+import { GitHubClient } from '@/lib/github/client';
+import { RequestBudget } from '@/lib/github/request-budget';
+import { createLogger, type LogRecord } from '@/lib/logging/logger';
+import { SCORING_VERSION } from '@/lib/scoring/weights';
+import { MemoryAnalysisStore } from '@/lib/store/memory-store';
+
+const NOW = new Date('2026-06-01T12:00:00Z');
+const REF = { owner: 'acme', name: 'widget' };
+const REPO_PATH = 'repos/acme/widget';
+
+const REPOSITORY = {
+  id: 42,
+  name: 'widget',
+  full_name: 'acme/widget',
+  owner: { login: 'acme' },
+  html_url: 'https://github.com/acme/widget',
+  description: 'A widget',
+  created_at: '2020-01-01T00:00:00Z',
+  pushed_at: '2026-05-30T00:00:00Z',
+  default_branch: 'main',
+  archived: false,
+  fork: false,
+  stargazers_count: 100,
+  forks_count: 10,
+  open_issues_count: 3,
+  has_issues: true,
+  homepage: null,
+  topics: ['tools'],
+  license: { spdx_id: 'MIT' },
+};
+
+/** A client whose only successful endpoint is the repository itself. */
+function stubClient(budget: RequestBudget, onRequest?: () => void) {
+  const fetchImpl = vi.fn(async (url: string | URL | Request) => {
+    onRequest?.();
+    const pathname = new URL(String(url)).pathname.replace(/^\//, '');
+
+    if (pathname === REPO_PATH) {
+      return new Response(JSON.stringify(REPOSITORY), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }
+
+    return new Response(JSON.stringify({ message: 'Not Found' }), {
+      status: 404,
+      headers: { 'content-type': 'application/json' },
+    });
+  }) as unknown as typeof fetch;
+
+  return new GitHubClient({
+    token: 'test-token',
+    fetchImpl,
+    sleep: async () => {},
+    random: () => 0.5,
+    budget,
+  });
+}
+
+function makeService(
+  overrides: Partial<ConstructorParameters<typeof AnalysisService>[0]> = {},
+) {
+  const records: LogRecord[] = [];
+  const store = new MemoryAnalysisStore();
+  let clock = NOW;
+  let idCounter = 0;
+  let githubCalls = 0;
+
+  const service = new AnalysisService({
+    store,
+    logger: createLogger({
+      write: (line) => records.push(JSON.parse(line) as LogRecord),
+      now: () => clock,
+    }),
+    now: () => clock,
+    generateId: () => `analysis-${++idCounter}`,
+    createClient: (budget) => stubClient(budget, () => (githubCalls += 1)),
+    ...overrides,
+  });
+
+  return {
+    service,
+    store,
+    records,
+    events: () => records.map((r) => r.event),
+    githubCalls: () => githubCalls,
+    advance: (ms: number) => {
+      clock = new Date(clock.getTime() + ms);
+    },
+  };
+}
+
+describe('AnalysisService', () => {
+  it('analyzes a repository and returns a scored result', async () => {
+    const { service } = makeService();
+    const outcome = await service.analyze(REF);
+
+    expect(outcome.cached).toBe(false);
+    expect(outcome.result.repository.fullName).toBe('acme/widget');
+    expect(outcome.result.scoringVersion).toBe(SCORING_VERSION);
+    expect(outcome.result.categories).toHaveLength(7);
+  });
+
+  it('persists the analysis so it can be served from cache', async () => {
+    const { service, store } = makeService();
+    await service.analyze(REF);
+
+    const stored = await store.findLatest(42);
+    expect(stored?.result.repository.githubId).toBe(42);
+  });
+
+  describe('caching', () => {
+    it('serves a fresh cached analysis without contacting GitHub', async () => {
+      const { service, githubCalls } = makeService();
+
+      await service.analyze(REF);
+      const callsAfterFirst = githubCalls();
+
+      const second = await service.analyze(REF);
+
+      expect(second.cached).toBe(true);
+      expect(githubCalls()).toBe(callsAfterFirst);
+    });
+
+    it('re-analyzes once the freshness window has passed', async () => {
+      const { service, advance, githubCalls } = makeService({ freshnessMinutes: 15 });
+
+      await service.analyze(REF);
+      const callsAfterFirst = githubCalls();
+
+      advance(16 * 60_000);
+      const second = await service.analyze(REF);
+
+      expect(second.cached).toBe(false);
+      expect(githubCalls()).toBeGreaterThan(callsAfterFirst);
+    });
+
+    it('serves from cache right up to the freshness boundary', async () => {
+      const { service, advance } = makeService({ freshnessMinutes: 15 });
+
+      await service.analyze(REF);
+      advance(14 * 60_000);
+
+      expect((await service.analyze(REF)).cached).toBe(true);
+    });
+
+    it('reports how old a cached result is', async () => {
+      const { service, advance } = makeService();
+
+      await service.analyze(REF);
+      advance(7 * 60_000);
+
+      expect((await service.analyze(REF)).ageSeconds).toBe(420);
+    });
+
+    it('bypasses the cache on a forced refresh', async () => {
+      const { service, githubCalls } = makeService();
+
+      await service.analyze(REF);
+      const callsAfterFirst = githubCalls();
+
+      const refreshed = await service.analyze(REF, { forceRefresh: true });
+
+      expect(refreshed.cached).toBe(false);
+      expect(githubCalls()).toBeGreaterThan(callsAfterFirst);
+    });
+
+    it('ignores a cached analysis produced under a different scoring version', async () => {
+      // Its numbers mean something else, so serving it would misrepresent
+      // them as current.
+      const { service, store, githubCalls } = makeService();
+      await service.analyze(REF);
+
+      const stored = await store.findLatest(42);
+      if (stored === null) throw new Error('expected a stored analysis');
+      await store.save({
+        ...stored,
+        result: { ...stored.result, scoringVersion: '0.9.0' },
+      });
+
+      const callsBefore = githubCalls();
+      const second = await service.analyze(REF);
+
+      expect(second.cached).toBe(false);
+      expect(githubCalls()).toBeGreaterThan(callsBefore);
+    });
+
+    it('is keyed case-insensitively on the repository name', async () => {
+      const { service } = makeService();
+
+      await service.analyze(REF);
+      const second = await service.analyze({ owner: 'ACME', name: 'Widget' });
+
+      expect(second.cached).toBe(true);
+    });
+  });
+
+  describe('deduplication', () => {
+    it('shares one analysis across concurrent requests', async () => {
+      // Ten simultaneous visitors to a popular repository should cost one
+      // analysis, not ten.
+      const { service, githubCalls } = makeService();
+
+      const outcomes = await Promise.all(
+        Array.from({ length: 10 }, () => service.analyze(REF)),
+      );
+
+      expect(outcomes).toHaveLength(10);
+      const ids = new Set(outcomes.map((o) => o.result.analysisId));
+      expect(ids.size).toBe(1);
+
+      // One analysis worth of requests, not ten.
+      expect(githubCalls()).toBeLessThan(30);
+    });
+
+    it('releases the in-flight entry so later requests still work', async () => {
+      const { service } = makeService();
+
+      await Promise.all([service.analyze(REF), service.analyze(REF)]);
+      const later = await service.analyze(REF, { forceRefresh: true });
+
+      expect(later.result).toBeDefined();
+    });
+
+    it('does not let a forced refresh join a cached-path request', async () => {
+      const { service } = makeService();
+
+      const [normal, forced] = await Promise.all([
+        service.analyze(REF),
+        service.analyze(REF, { forceRefresh: true }),
+      ]);
+
+      expect(normal.result.analysisId).not.toBe(forced.result.analysisId);
+    });
+  });
+
+  describe('failures', () => {
+    it('propagates a repository-level failure', async () => {
+      const { service } = makeService({
+        createClient: (budget) =>
+          new GitHubClient({
+            token: 'test-token',
+            budget,
+            sleep: async () => {},
+            fetchImpl: (async () =>
+              new Response(JSON.stringify({ message: 'Not Found' }), {
+                status: 404,
+                headers: { 'content-type': 'application/json' },
+              })) as unknown as typeof fetch,
+          }),
+      });
+
+      await expect(service.analyze(REF)).rejects.toMatchObject({ kind: 'not_found' });
+    });
+
+    it('still returns a result when the store cannot save', async () => {
+      // The user's analysis succeeded. A persistence failure means the cache
+      // misses next time, not that the work is discarded.
+      const failingStore = {
+        findLatest: async () => null,
+        findIdByFullName: async () => null,
+        save: async () => {
+          throw new Error('database unreachable');
+        },
+      };
+
+      const { service, events } = makeService({ store: failingStore });
+      const outcome = await service.analyze(REF);
+
+      expect(outcome.result).toBeDefined();
+      expect(events()).toContain('store_unavailable');
+    });
+
+    it('treats an unreadable store as a cache miss', async () => {
+      const failingStore = {
+        findLatest: async () => null,
+        findIdByFullName: async () => {
+          throw new Error('database unreachable');
+        },
+        save: async () => {},
+      };
+
+      const { service } = makeService({ store: failingStore });
+      expect((await service.analyze(REF)).cached).toBe(false);
+    });
+  });
+
+  describe('logging', () => {
+    it('logs the start and completion of an analysis with a shared id', async () => {
+      const { service, records } = makeService();
+      await service.analyze(REF);
+
+      const started = records.find((r) => r.event === 'analysis_started');
+      const completed = records.find((r) => r.event === 'analysis_completed');
+
+      expect(started?.analysisId).toBeDefined();
+      expect(completed?.analysisId).toBe(started?.analysisId);
+      expect(completed?.repository).toBe('acme/widget');
+      expect(typeof completed?.durationMs).toBe('number');
+    });
+
+    it('logs a cache hit with the age of the result', async () => {
+      const { service, advance, records } = makeService();
+
+      await service.analyze(REF);
+      advance(60_000);
+      await service.analyze(REF);
+
+      const hit = records.find((r) => r.event === 'cache_hit');
+      expect(hit?.ageSeconds).toBe(60);
+    });
+
+    it('logs a failure with its reason', async () => {
+      const { service, records } = makeService({
+        createClient: (budget) =>
+          new GitHubClient({
+            token: 'test-token',
+            budget,
+            sleep: async () => {},
+            fetchImpl: (async () =>
+              new Response('{}', {
+                status: 404,
+                headers: { 'content-type': 'application/json' },
+              })) as unknown as typeof fetch,
+          }),
+      });
+
+      await service.analyze(REF).catch(() => {});
+
+      const failed = records.find((r) => r.event === 'analysis_failed');
+      expect(failed?.reason).toBe('not_found');
+    });
+
+    it('never writes a token into any log line', async () => {
+      const { service, records } = makeService();
+      await service.analyze(REF);
+
+      const serialized = JSON.stringify(records);
+      expect(serialized).not.toContain('test-token');
+      expect(serialized.toLowerCase()).not.toContain('authorization');
+    });
+  });
+});

--- a/tests/unit/infrastructure.test.ts
+++ b/tests/unit/infrastructure.test.ts
@@ -1,0 +1,217 @@
+import { describe, expect, it } from 'vitest';
+
+import { createLogger, type LogRecord } from '@/lib/logging/logger';
+import { RateLimiter } from '@/lib/rate-limit';
+import { MemoryAnalysisStore } from '@/lib/store/memory-store';
+import type { StoredAnalysis } from '@/lib/store/types';
+
+import { NOW, buildHealthySnapshot } from '../support/snapshot-builder';
+
+function makeLogger() {
+  const lines: string[] = [];
+  const logger = createLogger({
+    write: (line) => lines.push(line),
+    now: () => NOW,
+  });
+  return { logger, lines, records: () => lines.map((l) => JSON.parse(l) as LogRecord) };
+}
+
+describe('logger', () => {
+  it('writes one JSON object per line', () => {
+    const { logger, lines } = makeLogger();
+
+    logger.info('analysis_started', { repository: 'acme/widget' });
+    logger.info('analysis_completed', { repository: 'acme/widget' });
+
+    expect(lines).toHaveLength(2);
+    for (const line of lines) {
+      expect(() => JSON.parse(line)).not.toThrow();
+      expect(line).not.toContain('\n');
+    }
+  });
+
+  it('includes level, event, and timestamp on every record', () => {
+    const { logger, records } = makeLogger();
+    logger.warn('rate_limit_reached', { repository: 'acme/widget' });
+
+    const record = records()[0];
+    expect(record?.level).toBe('warn');
+    expect(record?.event).toBe('rate_limit_reached');
+    expect(record?.timestamp).toBe(NOW.toISOString());
+  });
+
+  it.each([
+    'token',
+    'githubToken',
+    'authorization',
+    'password',
+    'secret',
+    'apiKey',
+    'accessToken',
+    'cookie',
+  ])('drops the %s field defensively', (key) => {
+    // The real protection is that no caller passes these. Dropping them here
+    // means a future careless caller degrades to a missing field rather than a
+    // leaked credential.
+    const { logger, lines } = makeLogger();
+    logger.info('analysis_started', { [key]: 'ghp_secretvalue' });
+
+    expect(lines[0]).not.toContain('ghp_secretvalue');
+    expect(lines[0]).not.toContain(key);
+  });
+
+  it('omits undefined fields rather than emitting null', () => {
+    const { logger, records } = makeLogger();
+    logger.info('cache_miss', { repository: 'acme/widget', durationMs: undefined });
+
+    expect(records()[0]).not.toHaveProperty('durationMs');
+  });
+
+  it('keeps a legitimately null field, which carries meaning', () => {
+    const { logger, records } = makeLogger();
+    logger.info('analysis_completed', { score: null });
+
+    expect(records()[0]?.score).toBeNull();
+  });
+});
+
+describe('MemoryAnalysisStore', () => {
+  function entry(githubId: number, fullName: string, createdAt = NOW): StoredAnalysis {
+    const snapshot = buildHealthySnapshot({
+      identity: { githubId, fullName },
+    });
+    return {
+      snapshot,
+      createdAt,
+      result: {
+        scoringVersion: '1.0.0',
+        analysisId: `analysis-${githubId}`,
+        analyzedAt: createdAt.toISOString(),
+        repository: snapshot.identity,
+        overall: {
+          score: 80,
+          confidence: 'high',
+          contributions: [],
+          excluded: [],
+          formula: '',
+        },
+        categories: [],
+        findings: [],
+        limitations: [],
+      },
+    };
+  }
+
+  it('returns null for a repository it has never seen', async () => {
+    const store = new MemoryAnalysisStore();
+    expect(await store.findLatest(1)).toBeNull();
+    expect(await store.findIdByFullName('acme/widget')).toBeNull();
+  });
+
+  it('stores and retrieves by GitHub id', async () => {
+    const store = new MemoryAnalysisStore();
+    await store.save(entry(42, 'acme/widget'));
+
+    expect((await store.findLatest(42))?.result.analysisId).toBe('analysis-42');
+  });
+
+  it('resolves a full name to its GitHub id case-insensitively', async () => {
+    const store = new MemoryAnalysisStore();
+    await store.save(entry(42, 'acme/widget'));
+
+    expect(await store.findIdByFullName('ACME/Widget')).toBe(42);
+  });
+
+  it('keeps history keyed on identity when a repository is renamed', async () => {
+    // The reason identity is the numeric id: a rename must not fork one
+    // project's history into two records.
+    const store = new MemoryAnalysisStore();
+    await store.save(entry(42, 'acme/widget'));
+    await store.save(entry(42, 'acme/gadget'));
+
+    expect(await store.findIdByFullName('acme/gadget')).toBe(42);
+    expect((await store.findLatest(42))?.result.repository.fullName).toBe('acme/gadget');
+  });
+
+  it('replaces the previous entry for a repository', async () => {
+    const store = new MemoryAnalysisStore();
+    await store.save(entry(42, 'acme/widget', new Date('2026-01-01T00:00:00Z')));
+    await store.save(entry(42, 'acme/widget', new Date('2026-06-01T00:00:00Z')));
+
+    expect(store.size).toBe(1);
+    expect((await store.findLatest(42))?.createdAt.toISOString()).toBe(
+      '2026-06-01T00:00:00.000Z',
+    );
+  });
+
+  it('evicts the oldest entries past its cap', async () => {
+    const store = new MemoryAnalysisStore(3);
+
+    for (let id = 1; id <= 5; id += 1) {
+      await store.save(entry(id, `acme/repo-${id}`));
+    }
+
+    expect(store.size).toBe(3);
+    expect(await store.findLatest(1)).toBeNull();
+    expect(await store.findLatest(5)).not.toBeNull();
+    // The evicted entry's name lookup goes with it.
+    expect(await store.findIdByFullName('acme/repo-1')).toBeNull();
+  });
+});
+
+describe('RateLimiter', () => {
+  it('allows requests up to the limit', () => {
+    const limiter = new RateLimiter(3, 60_000, () => 0);
+
+    expect(limiter.check('a').allowed).toBe(true);
+    expect(limiter.check('a').allowed).toBe(true);
+    expect(limiter.check('a').allowed).toBe(true);
+    expect(limiter.check('a').allowed).toBe(false);
+  });
+
+  it('reports how many requests remain', () => {
+    const limiter = new RateLimiter(3, 60_000, () => 0);
+
+    expect(limiter.check('a').remaining).toBe(2);
+    expect(limiter.check('a').remaining).toBe(1);
+    expect(limiter.check('a').remaining).toBe(0);
+  });
+
+  it('reports a positive retry-after when blocked', () => {
+    const limiter = new RateLimiter(1, 60_000, () => 0);
+
+    limiter.check('a');
+    const blocked = limiter.check('a');
+
+    expect(blocked.allowed).toBe(false);
+    expect(blocked.retryAfterSeconds).toBeGreaterThan(0);
+  });
+
+  it('does not leak one client’s limit into another', () => {
+    const limiter = new RateLimiter(1, 60_000, () => 0);
+
+    expect(limiter.check('client-a').allowed).toBe(true);
+    expect(limiter.check('client-b').allowed).toBe(true);
+    expect(limiter.check('client-a').allowed).toBe(false);
+  });
+
+  it('resets after the window elapses', () => {
+    let now = 0;
+    const limiter = new RateLimiter(1, 60_000, () => now);
+
+    expect(limiter.check('a').allowed).toBe(true);
+    expect(limiter.check('a').allowed).toBe(false);
+
+    now = 60_001;
+    expect(limiter.check('a').allowed).toBe(true);
+  });
+
+  it('still blocks one millisecond before the window ends', () => {
+    let now = 0;
+    const limiter = new RateLimiter(1, 60_000, () => now);
+
+    limiter.check('a');
+    now = 59_999;
+    expect(limiter.check('a').allowed).toBe(false);
+  });
+});

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -45,7 +45,15 @@ export default defineConfig({
       provider: 'v8',
       reporter: ['text', 'lcov'],
       include: ['src/lib/**/*.ts'],
-      exclude: ['src/lib/**/index.ts', 'src/lib/store/prisma-*.ts'],
+      // Excluded because they are wiring, not logic: `container.ts` reads
+      // environment variables and picks an implementation, and the Prisma
+      // store needs a live database. Both are exercised by E2E rather than
+      // by unit tests, and covering them here would mean testing mocks.
+      exclude: [
+        'src/lib/**/index.ts',
+        'src/lib/store/prisma-*.ts',
+        'src/lib/analysis/container.ts',
+      ],
       thresholds: {
         // The scoring and normalization layers are the correctness core of the
         // product, so the bar is set against src/lib rather than the whole app.


### PR DESCRIPTION
## Summary

Wires the pipeline into an `AnalysisService` and gives it somewhere to store results.

Closes #19, closes #26

## Why the policies live in the service

Caching, deduplication, and version invalidation are here rather than at the call site so every entry point gets them consistently:

- **Freshness** — a cached analysis younger than 15 minutes is served without touching GitHub.
- **Deduplication** — concurrent requests for the same repository share one in-flight promise. Ten simultaneous visitors to a popular repository cost one analysis, not ten. Tested directly.
- **Version invalidation** — a cached analysis produced under a different `scoringVersion` is *not* served. Its numbers mean something else, and serving them as current would misrepresent them.

## Why persistence is behind an interface

Not for its own sake — for a concrete requirement: **the application must run without a database.** No `DATABASE_URL` means the in-memory store, tests use the same one, and CI needs no Postgres service container. The tradeoff is stated where a user will see it: analyses do not survive a restart.

## Data model

Repository identity is GitHub's **numeric id**, not `owner/name`. Repositories get renamed and transferred; keying on the mutable name would silently fork one project's history into two records. There's a test for exactly that:

```ts
it('keeps history keyed on identity when a repository is renamed', …)
```

Analyses are append-only, so a cache read is "the most recent row, if fresh enough" and historical score tracking needs no schema change to add later.

A persistence failure never fails an analysis that already succeeded — the user gets their result, the cache simply misses next time, and `store_unavailable` is logged.

## Prisma 7

Prisma 7 no longer accepts `url` in the schema's datasource block. This adds `prisma.config.ts` and constructs the client through the `pg` driver adapter.

One wrinkle worth noting: the config declares its datasource **only when `DATABASE_URL` is actually set**. Prisma's `env()` helper treats a missing variable as fatal, which would break both `prisma generate` in CI and running the app without a database.

## Logging

One JSON object per line, correlated by analysis id, covering `analysis_started`, `analysis_completed`, `analysis_failed`, `rate_limit_reached`, `cache_hit`, `cache_miss`, and `store_unavailable`.

Credential-shaped keys (`token`, `authorization`, `secret`, …) are dropped defensively. The real protection is that no caller passes them; the drop-list means a future careless caller degrades to a missing field rather than a leaked credential. A test asserts a token reaches no log line.

## Testing

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test` — 391 passing
- [x] `npm run build`

```
File          | % Stmts | % Branch | % Funcs | % Lines
--------------|---------|----------|---------|--------
All files     |   93.92 |     85.5 |   91.06 |   95.23
 lib/analysis |   93.22 |    74.28 |    87.5 |   94.64
 lib/store    |      95 |    81.81 |     100 |     100
```

`container.ts` and the Prisma store are excluded from coverage, with the reason written in `vitest.config.mts`: they are wiring that reads environment variables and needs a live database. Covering them here would mean testing mocks; E2E exercises them instead.

## Risks

**The rate limiter is in-memory and per-instance.** Across several instances it limits per instance rather than globally. That is written down in the module comment rather than hidden, because someone scaling this horizontally needs to know the guarantee weakens. A distributed limiter needs shared state, and no current requirement justifies adding Redis.

**Prisma migrations have not been run against a live database yet** — that happens in #28. The schema typechecks and the client generates, but the SQL is unproven until then.

## Checklist

- [x] Scope matches the linked issues
- [x] Tests cover the new behavior, including null and partial-data paths
- [x] No scoring rules changed, so no version bump required
- [x] No secrets, tokens, or personal data added to the repository or logs
- [x] Documentation updated where behavior changed (CHANGELOG, .env.example)