### PR TITLE
feat: build the analysis dashboard and connect it to the pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# Local editor/tooling scratch
+/.claude/

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -41,6 +41,11 @@ const eslintConfig = defineConfig([
     files: ['tests/**/*.{ts,tsx}'],
     rules: { '@typescript-eslint/no-explicit-any': 'off' },
   },
+  {
+    // Command-line tools write to stdout; that is their interface.
+    files: ['scripts/**/*.{ts,mts}'],
+    rules: { 'no-console': 'off' },
+  },
 ]);
 
 export default eslintConfig;

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,29 +1,14 @@
 import type { NextConfig } from 'next';
 
 /**
- * Content Security Policy.
+ * Static security headers.
  *
- * RepoSignal renders only its own markup and server-generated inline SVG, so
- * the policy can be tight. `'unsafe-inline'` is required for styles because
- * Next.js injects inline style tags for streaming; scripts do not need it in
- * production, where Next emits external bundles only.
+ * The Content Security Policy is deliberately *not* here: it needs a fresh
+ * nonce per request, so it is set in `src/proxy.ts` instead. A static CSP
+ * cannot carry a nonce, and without one Next.js's streaming inline scripts are
+ * blocked.
  */
-const contentSecurityPolicy = [
-  "default-src 'self'",
-  "base-uri 'self'",
-  "form-action 'self'",
-  "frame-ancestors 'none'",
-  "object-src 'none'",
-  "img-src 'self' data: https://avatars.githubusercontent.com",
-  "style-src 'self' 'unsafe-inline'",
-  `script-src 'self'${process.env.NODE_ENV === 'development' ? " 'unsafe-eval'" : ''}`,
-  "connect-src 'self'",
-  "font-src 'self'",
-  'upgrade-insecure-requests',
-].join('; ');
-
 const securityHeaders = [
-  { key: 'Content-Security-Policy', value: contentSecurityPolicy },
   { key: 'X-Content-Type-Options', value: 'nosniff' },
   { key: 'X-Frame-Options', value: 'DENY' },
   { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "db:generate": "prisma generate",
     "db:migrate": "prisma migrate dev",
     "db:deploy": "prisma migrate deploy",
-    "db:studio": "prisma studio"
+    "db:studio": "prisma studio",
+    "analyze": "tsx scripts/analyze.mts"
   },
   "dependencies": {
     "@prisma/adapter-pg": "^7.9.1",

--- a/scripts/analyze.mts
+++ b/scripts/analyze.mts
@@ -1,0 +1,83 @@
+/**
+ * Analyze a repository from the command line.
+ *
+ *   npm run analyze -- facebook/react
+ *
+ * Runs the real pipeline — collect, normalize, score — and prints the result.
+ * Useful for checking behaviour against the live API without the UI in the
+ * way, and for capturing fixtures.
+ *
+ * Requires GITHUB_TOKEN in the environment (or .env.local, which Next loads in
+ * development but this script does not — export it, or use `gh auth token`).
+ */
+import { GitHubClient } from '../src/lib/github/client';
+import { collectSnapshot } from '../src/lib/github/collector';
+import { RequestBudget } from '../src/lib/github/request-budget';
+import { analyzeSnapshot } from '../src/lib/scoring';
+import { parseRepositoryReference } from '../src/lib/validation/repository-reference';
+
+const input = process.argv[2];
+
+if (input === undefined) {
+  console.error('Usage: npm run analyze -- <owner/repository>');
+  process.exit(1);
+}
+
+const parsed = parseRepositoryReference(input);
+if (!parsed.ok) {
+  console.error(parsed.error);
+  process.exit(1);
+}
+
+const startedAt = performance.now();
+const client = new GitHubClient({ budget: new RequestBudget(60) });
+
+try {
+  const now = new Date();
+  const snapshot = await collectSnapshot(client, parsed.value, now);
+  const result = analyzeSnapshot(snapshot, { now, analysisId: 'cli' });
+  const elapsedMs = Math.round(performance.now() - startedAt);
+
+  console.log(`\n${result.repository.fullName}`);
+  console.log(
+    `Engineering health: ${result.overall.score ?? 'Insufficient data'}${
+      result.overall.score === null ? '' : ' / 100'
+    } (${result.overall.confidence} confidence)\n`,
+  );
+
+  for (const category of result.categories) {
+    const score = category.score === null ? 'Insufficient data' : String(category.score);
+    console.log(`  ${category.label.padEnd(22)} ${score.padStart(18)}`);
+  }
+
+  const bySeverity = result.findings.filter(
+    (finding) => finding.severity === 'high' || finding.severity === 'medium',
+  );
+
+  if (bySeverity.length > 0) {
+    console.log('\nHighest-priority findings:');
+    for (const finding of bySeverity) {
+      console.log(`  [${finding.severity}] ${finding.title}`);
+    }
+  }
+
+  if (result.limitations.length > 0) {
+    console.log('\nLimitations:');
+    for (const limitation of result.limitations) {
+      console.log(`  - ${limitation}`);
+    }
+  }
+
+  console.log(
+    `\n${snapshot.collection.requestsMade} GitHub requests in ${elapsedMs}ms · ` +
+      `rate limit remaining: ${snapshot.collection.rateLimitRemaining ?? 'unknown'} · ` +
+      `scoring version ${result.scoringVersion}\n`,
+  );
+} catch (error) {
+  const kind =
+    error !== null && typeof error === 'object' && 'kind' in error
+      ? String((error as { kind: unknown }).kind)
+      : 'unexpected';
+  console.error(`Analysis failed (${kind}).`);
+  process.exit(1);
+}

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -1,0 +1,38 @@
+'use server';
+
+import { redirect } from 'next/navigation';
+
+import { parseRepositoryReference } from '@/lib/validation/repository-reference';
+
+export interface SearchState {
+  error?: string;
+  /** Echoed back so the field keeps its value after a failed submit. */
+  value?: string;
+}
+
+/**
+ * Handles the repository search form.
+ *
+ * Validation happens here, on the server, before any redirect. The client-side
+ * check in the form is a convenience for immediate feedback, not the boundary —
+ * this is.
+ *
+ * The rejected value is echoed back into the field so the user can correct a
+ * typo rather than retype the whole thing. It is returned as data and rendered
+ * by React as text, never interpolated into markup.
+ */
+export async function analyzeRepository(
+  _previous: SearchState,
+  formData: FormData,
+): Promise<SearchState> {
+  const raw = formData.get('repository');
+  const input = typeof raw === 'string' ? raw : '';
+
+  const parsed = parseRepositoryReference(input);
+
+  if (!parsed.ok) {
+    return { error: parsed.error, value: input };
+  }
+
+  redirect(`/r/${parsed.value.owner}/${parsed.value.name}`);
+}

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import Link from 'next/link';
+
+/**
+ * Route-level error boundary.
+ *
+ * Renders a safe message only. `error.message` is deliberately not shown — in
+ * production Next.js replaces it with a digest anyway, and displaying raw error
+ * text is how internal details leak into a page.
+ */
+export default function ErrorBoundary({ reset }: { error: Error; reset: () => void }) {
+  return (
+    <div className="mx-auto w-full max-w-3xl px-6 py-16">
+      <h1 className="text-2xl font-semibold">Something went wrong</h1>
+      <p className="text-muted mt-3">
+        RepoSignal could not finish rendering this page. The failure has been logged.
+      </p>
+
+      <div className="mt-6 flex flex-wrap gap-4">
+        <button
+          type="button"
+          onClick={reset}
+          className="bg-accent text-accent-contrast rounded-md px-4 py-2 font-medium"
+        >
+          Try again
+        </button>
+        <Link href="/" className="text-accent self-center underline underline-offset-4">
+          Back to the homepage
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,16 @@ import type { Metadata } from 'next';
 import Link from 'next/link';
 import './globals.css';
 
+/**
+ * Every route renders dynamically.
+ *
+ * The nonce in the Content Security Policy (see `src/proxy.ts`) is injected
+ * during rendering, so a prerendered page would carry a nonce that no longer
+ * matches the header its visitor receives, and its scripts would be blocked.
+ * Prerendering the homepage is the price of a strict script policy.
+ */
+export const dynamic = 'force-dynamic';
+
 export const metadata: Metadata = {
   title: {
     default: 'RepoSignal — GitHub engineering health analysis',

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,22 @@
+import Link from 'next/link';
+
+export default function NotFound() {
+  return (
+    <div className="mx-auto w-full max-w-3xl px-6 py-16">
+      <h1 className="text-2xl font-semibold">Page not found</h1>
+      <p className="text-muted mt-3">
+        That page does not exist. If you were looking for a repository analysis, the
+        address should look like{' '}
+        <code className="bg-surface rounded px-1 py-0.5 font-mono text-sm">
+          /r/owner/repository
+        </code>
+        .
+      </p>
+      <p className="mt-6">
+        <Link href="/" className="text-accent underline underline-offset-4">
+          Analyze a repository
+        </Link>
+      </p>
+    </div>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,24 +1,109 @@
+import { RepositorySearch } from '@/components/repository-search';
+import { CATEGORY_LABELS, CATEGORY_WEIGHTS } from '@/lib/scoring/weights';
+import type { CategoryKey } from '@/types/analysis';
+
+const MEASURED: Array<{ key: CategoryKey; description: string }> = [
+  {
+    key: 'activity',
+    description: 'Commit cadence, last push, and how recently and regularly it releases.',
+  },
+  {
+    key: 'pullRequests',
+    description: 'How long pull requests stay open, and how quickly they merge.',
+  },
+  {
+    key: 'issues',
+    description:
+      'Backlog age, stale issues, and whether issues close as fast as they arrive.',
+  },
+  {
+    key: 'ci',
+    description:
+      'Whether automated checks exist on the default branch, and whether they pass.',
+  },
+  {
+    key: 'documentation',
+    description:
+      'README, LICENSE, CONTRIBUTING, templates, and a documentation directory.',
+  },
+  {
+    key: 'repository',
+    description: 'Lockfiles, dependency automation, CODEOWNERS, tags, and metadata.',
+  },
+  {
+    key: 'security',
+    description: 'A security policy, dependency automation, and scanning declared in CI.',
+  },
+];
+
 export default function HomePage() {
   return (
-    <div className="mx-auto w-full max-w-5xl px-6 py-16">
+    <div className="mx-auto w-full max-w-3xl px-6 py-16">
       <h1 className="text-3xl font-semibold tracking-tight text-balance sm:text-4xl">
         Understand a GitHub repository in 30 seconds.
       </h1>
-      <p className="text-muted mt-4 max-w-2xl text-lg">
+      <p className="text-muted mt-4 text-lg">
         RepoSignal analyzes engineering health using public repository evidence.
       </p>
-      <p className="text-muted mt-8 text-sm">
-        The analysis pipeline is under construction. See{' '}
-        <a
-          className="text-accent underline underline-offset-4"
-          href="https://github.com/mateoosoriodelhonte/reposignal/milestone/1"
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-          the v1.0 milestone
-        </a>{' '}
-        for progress.
-      </p>
+
+      <div className="mt-8">
+        <RepositorySearch />
+      </div>
+
+      <section className="mt-16" aria-labelledby="what-it-measures">
+        <h2 id="what-it-measures" className="text-xl font-semibold">
+          What RepoSignal measures
+        </h2>
+        <p className="text-muted mt-2 text-sm">
+          Seven categories, each scored independently and each fully explainable. Weights
+          are shown because they are a judgment call, not a fact.
+        </p>
+
+        <dl className="mt-6 flex flex-col gap-4">
+          {MEASURED.map(({ key, description }) => (
+            <div
+              key={key}
+              className="border-border-subtle flex flex-col gap-1 border-b pb-4"
+            >
+              <dt className="flex items-baseline justify-between gap-4">
+                <span className="font-medium">{CATEGORY_LABELS[key]}</span>
+                <span className="text-muted shrink-0 text-xs tabular-nums">
+                  weight {CATEGORY_WEIGHTS[key]}
+                </span>
+              </dt>
+              <dd className="text-muted text-sm">{description}</dd>
+            </div>
+          ))}
+        </dl>
+      </section>
+
+      <section className="mt-12" aria-labelledby="how-it-works">
+        <h2 id="how-it-works" className="text-xl font-semibold">
+          How the scores work
+        </h2>
+
+        <div className="text-muted mt-4 flex flex-col gap-3 text-sm">
+          <p>
+            Every number can be traced back to the public GitHub data it came from. Each
+            category shows the metrics examined, their raw values, the weights applied,
+            the thresholds used, and links to the evidence.
+          </p>
+          <p>
+            <span className="text-foreground font-medium">
+              Missing data is not treated as bad news.
+            </span>{' '}
+            When something cannot be observed — GitHub has not computed commit statistics,
+            or branch protection needs permissions RepoSignal does not have — it is
+            reported as unknown and excluded from the score, with its weight redistributed
+            across what could be measured. It is never counted as zero.
+          </p>
+          <p>
+            RepoSignal reports what it can observe. It does not read your code, does not
+            scan for vulnerabilities, and does not use a language model to produce or
+            adjust any score.
+          </p>
+        </div>
+      </section>
     </div>
   );
 }

--- a/src/app/r/[owner]/[repository]/page.tsx
+++ b/src/app/r/[owner]/[repository]/page.tsx
@@ -1,0 +1,271 @@
+import type { Metadata } from 'next';
+import { notFound } from 'next/navigation';
+import { Suspense } from 'react';
+
+import { AnalysisError, PartialDataBanner } from '@/components/analysis-error';
+import { CategoryCard } from '@/components/category-card';
+import { FindingsList } from '@/components/findings';
+import { CategoryScoreBar, OverallScore } from '@/components/score-display';
+import { getAnalysisService } from '@/lib/analysis/container';
+import { parseRepositoryReference } from '@/lib/validation/repository-reference';
+import type { AnalysisResult } from '@/types/analysis';
+
+/**
+ * The analysis page.
+ *
+ * Server rendered end to end. The only client JavaScript on this route is the
+ * search form in the header on the homepage — the report itself is static
+ * markup, which is why the disclosures are `<details>` elements rather than
+ * state-driven components.
+ *
+ * The page renders `AnalysisResult` and calculates nothing. Every number on
+ * screen was produced by a tested scoring function.
+ */
+
+export async function generateMetadata(
+  props: PageProps<'/r/[owner]/[repository]'>,
+): Promise<Metadata> {
+  const { owner, repository } = await props.params;
+  const parsed = parseRepositoryReference(`${owner}/${repository}`);
+
+  if (!parsed.ok) return { title: 'Repository not found' };
+
+  const fullName = `${parsed.value.owner}/${parsed.value.name}`;
+  return {
+    title: `${fullName} — engineering health`,
+    description: `RepoSignal's evidence-backed engineering health analysis of ${fullName}.`,
+  };
+}
+
+export default function AnalysisPage(props: PageProps<'/r/[owner]/[repository]'>) {
+  return (
+    <Suspense fallback={<AnalysisSkeleton />}>
+      <AnalysisContent params={props.params} />
+    </Suspense>
+  );
+}
+
+async function AnalysisContent({
+  params,
+}: Pick<PageProps<'/r/[owner]/[repository]'>, 'params'>) {
+  const { owner, repository } = await params;
+
+  // The route segments are user input like any other, so they go through the
+  // same parser as the search form before anything is requested.
+  const parsed = parseRepositoryReference(`${owner}/${repository}`);
+  if (!parsed.ok) notFound();
+
+  const fullName = `${parsed.value.owner}/${parsed.value.name}`;
+  const service = await getAnalysisService();
+
+  let outcome;
+  try {
+    outcome = await service.analyze(parsed.value);
+  } catch (error) {
+    return <AnalysisError error={error} repository={fullName} />;
+  }
+
+  return (
+    <AnalysisReport
+      result={outcome.result}
+      cached={outcome.cached}
+      ageSeconds={outcome.ageSeconds}
+    />
+  );
+}
+
+function AnalysisReport({
+  result,
+  cached,
+  ageSeconds,
+}: {
+  result: AnalysisResult;
+  cached: boolean;
+  ageSeconds: number;
+}) {
+  const { repository, overall, categories, findings, limitations } = result;
+  const priorityFindings = findings.filter(
+    (finding) => finding.severity === 'high' || finding.severity === 'medium',
+  );
+
+  return (
+    <div className="mx-auto flex w-full max-w-4xl flex-col gap-10 px-6 py-12">
+      <header className="flex flex-col gap-4">
+        <div className="flex flex-wrap items-start justify-between gap-4">
+          <div>
+            <h1 className="text-2xl font-semibold tracking-tight">
+              {repository.fullName}
+            </h1>
+            {repository.description !== null && (
+              <p className="text-muted mt-1 max-w-2xl">{repository.description}</p>
+            )}
+            <p className="mt-2 flex flex-wrap gap-x-3 gap-y-1 text-sm">
+              <a
+                className="text-accent underline underline-offset-4"
+                href={repository.htmlUrl}
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                View on GitHub
+              </a>
+              {repository.isArchived && <span className="text-muted">Archived</span>}
+              {repository.isFork && <span className="text-muted">Fork</span>}
+            </p>
+          </div>
+
+          <OverallScore score={overall.score} confidence={overall.confidence} />
+        </div>
+
+        <p className="text-muted text-sm">
+          {cached ? <>Analyzed {formatAge(ageSeconds)}.</> : <>Analyzed just now.</>}{' '}
+          Scoring algorithm version {result.scoringVersion}.
+        </p>
+      </header>
+
+      <PartialDataBanner limitations={limitations} />
+
+      <section aria-labelledby="categories-heading" className="flex flex-col gap-4">
+        <h2 id="categories-heading" className="text-xl font-semibold">
+          Category scores
+        </h2>
+
+        <div className="border-border-subtle bg-surface-raised grid gap-x-8 gap-y-4 rounded-lg border p-5 sm:grid-cols-2">
+          {categories.map((category) => (
+            <CategoryScoreBar
+              key={category.key}
+              score={category.score}
+              label={category.label}
+            />
+          ))}
+        </div>
+      </section>
+
+      <section aria-labelledby="overall-method-heading">
+        <h2 id="overall-method-heading" className="text-xl font-semibold">
+          How the overall score was calculated
+        </h2>
+
+        <div className="border-border-subtle bg-surface-raised mt-4 rounded-lg border p-5">
+          {overall.score === null ? (
+            <p className="text-muted text-sm">{overall.formula}</p>
+          ) : (
+            <>
+              <p className="text-muted font-mono text-xs break-words">
+                {overall.formula}
+              </p>
+
+              <div className="mt-4 overflow-x-auto">
+                <table className="w-full min-w-[28rem] border-collapse text-left text-sm">
+                  <caption className="sr-only">
+                    Each category&apos;s score and the weight it was given
+                  </caption>
+                  <thead>
+                    <tr className="border-border-subtle text-muted border-b text-xs uppercase">
+                      <th scope="col" className="py-2 pr-4 font-medium">
+                        Category
+                      </th>
+                      <th scope="col" className="py-2 pr-4 font-medium">
+                        Score
+                      </th>
+                      <th scope="col" className="py-2 pr-4 font-medium">
+                        Declared weight
+                      </th>
+                      <th scope="col" className="py-2 font-medium">
+                        Effective weight
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {overall.contributions.map((contribution) => {
+                      const category = categories.find((c) => c.key === contribution.key);
+                      return (
+                        <tr
+                          key={contribution.key}
+                          className="border-border-subtle border-b"
+                        >
+                          <th scope="row" className="py-2 pr-4 font-medium">
+                            {category?.label ?? contribution.key}
+                          </th>
+                          <td className="py-2 pr-4 tabular-nums">{contribution.score}</td>
+                          <td className="text-muted py-2 pr-4 tabular-nums">
+                            {contribution.declaredWeight}
+                          </td>
+                          <td className="text-muted py-2 tabular-nums">
+                            {contribution.effectiveWeight}%
+                          </td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
+              </div>
+            </>
+          )}
+
+          {overall.excluded.length > 0 && (
+            <div className="mt-5">
+              <h3 className="text-sm font-medium">
+                Excluded from the score, with weight redistributed
+              </h3>
+              <ul className="text-muted mt-2 list-disc space-y-1 pl-5 text-sm">
+                {overall.excluded.map((entry) => {
+                  const category = categories.find((c) => c.key === entry.key);
+                  return (
+                    <li key={entry.key}>
+                      <span className="text-foreground font-medium">
+                        {category?.label ?? entry.key}:
+                      </span>{' '}
+                      {entry.reason}
+                    </li>
+                  );
+                })}
+              </ul>
+            </div>
+          )}
+        </div>
+      </section>
+
+      <section aria-labelledby="findings-heading">
+        <h2 id="findings-heading" className="text-xl font-semibold">
+          Highest-priority findings
+        </h2>
+        <p className="text-muted mt-1 mb-4 text-sm">
+          Observations RepoSignal could make from public data. Each states what was
+          observed, not why — intent is not something this data reveals.
+        </p>
+        <FindingsList
+          findings={priorityFindings}
+          emptyMessage="No high or medium severity findings were raised."
+        />
+      </section>
+
+      <section aria-labelledby="detail-heading" className="flex flex-col gap-4">
+        <h2 id="detail-heading" className="text-xl font-semibold">
+          Category detail
+        </h2>
+        {categories.map((category) => (
+          <CategoryCard key={category.key} category={category} />
+        ))}
+      </section>
+    </div>
+  );
+}
+
+function AnalysisSkeleton() {
+  return (
+    <div className="mx-auto w-full max-w-4xl px-6 py-12" aria-busy="true">
+      <p role="status" className="text-muted">
+        Analyzing repository…
+      </p>
+      <p className="text-muted mt-2 text-sm">
+        RepoSignal is reading public GitHub data. This usually takes a few seconds.
+      </p>
+    </div>
+  );
+}
+
+function formatAge(seconds: number): string {
+  if (seconds < 60) return 'less than a minute ago';
+  const minutes = Math.round(seconds / 60);
+  return minutes === 1 ? '1 minute ago' : `${minutes} minutes ago`;
+}

--- a/src/components/analysis-error.tsx
+++ b/src/components/analysis-error.tsx
@@ -1,0 +1,146 @@
+import Link from 'next/link';
+
+import { GitHubError, isRateLimitError } from '@/lib/github/errors';
+
+/**
+ * Failure states.
+ *
+ * Each error class gets its own explanation and its own next step. A generic
+ * "something went wrong" tells a user nothing they can act on, and hides
+ * whether the problem is theirs, GitHub's, or RepoSignal's.
+ *
+ * Nothing here exposes a stack trace or an internal detail.
+ */
+
+interface ErrorPresentation {
+  title: string;
+  body: string;
+  action?: string;
+}
+
+function describe(error: unknown, repository: string): ErrorPresentation {
+  if (isRateLimitError(error)) {
+    const resetsAt = error.resetAt;
+    const when =
+      resetsAt === null
+        ? 'shortly'
+        : resetsAt.toLocaleTimeString(undefined, {
+            hour: 'numeric',
+            minute: '2-digit',
+            timeZoneName: 'short',
+          });
+
+    return {
+      title: 'GitHub rate limit reached',
+      body: error.isSecondary
+        ? `GitHub is temporarily throttling requests. Access should return around ${when}.`
+        : `RepoSignal has used its GitHub API allowance for now. It resets around ${when}.`,
+      action: 'Analyses already cached are still available.',
+    };
+  }
+
+  if (error instanceof GitHubError) {
+    switch (error.kind) {
+      case 'not_found':
+        return {
+          title: 'Repository not found',
+          body: `GitHub has no public repository at ${repository}. It may be private, renamed, or deleted — RepoSignal only reads public data.`,
+          action: 'Check the owner and name, then try again.',
+        };
+      case 'forbidden':
+        return {
+          title: 'Repository is not accessible',
+          body: `GitHub refused access to ${repository}. This usually means the repository is private or has been made unavailable.`,
+          action: 'RepoSignal can only analyze public repositories.',
+        };
+      case 'timeout':
+        return {
+          title: 'GitHub did not respond in time',
+          body: 'The request to GitHub timed out before the analysis could finish.',
+          action: 'Try again in a moment.',
+        };
+      case 'network':
+        return {
+          title: 'Could not reach GitHub',
+          body: 'RepoSignal could not connect to the GitHub API.',
+          action: 'This is usually temporary. Try again shortly.',
+        };
+      case 'budget_exhausted':
+        return {
+          title: 'Analysis exceeded its request budget',
+          body: `Analyzing ${repository} needed more GitHub requests than one analysis is allowed to spend.`,
+          action:
+            'This is a limit RepoSignal imposes on itself to stay a good API citizen.',
+        };
+      default:
+        return {
+          title: 'GitHub returned an unexpected response',
+          body: `Something went wrong while analyzing ${repository}, and RepoSignal could not interpret GitHub's response.`,
+          action: 'Try again shortly.',
+        };
+    }
+  }
+
+  return {
+    title: 'Analysis could not be completed',
+    body: `Something went wrong while analyzing ${repository}.`,
+    action: 'Try again shortly.',
+  };
+}
+
+export function AnalysisError({
+  error,
+  repository,
+}: {
+  error: unknown;
+  repository: string;
+}) {
+  const { title, body, action } = describe(error, repository);
+
+  return (
+    <div className="mx-auto w-full max-w-3xl px-6 py-16">
+      <div className="border-border-subtle bg-surface-raised rounded-lg border p-6">
+        <h1 className="text-2xl font-semibold">{title}</h1>
+        <p className="text-muted mt-3">{body}</p>
+        {action !== undefined && <p className="text-muted mt-2 text-sm">{action}</p>}
+
+        <p className="mt-6">
+          <Link href="/" className="text-accent underline underline-offset-4">
+            Analyze a different repository
+          </Link>
+        </p>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Shown when part of the data could not be collected.
+ *
+ * The analysis that succeeded is still rendered — discarding good partial data
+ * because one endpoint failed would serve nobody. The banner names what is
+ * missing so the reader can weigh the result accordingly.
+ */
+export function PartialDataBanner({ limitations }: { limitations: string[] }) {
+  if (limitations.length === 0) return null;
+
+  return (
+    <aside
+      className="border-severity-medium bg-surface rounded-lg border p-4"
+      aria-labelledby="partial-data-heading"
+    >
+      <h2 id="partial-data-heading" className="text-sm font-semibold">
+        Some data could not be retrieved
+      </h2>
+      <p className="text-muted mt-1 text-sm">
+        The analysis below is based on what RepoSignal could observe. Anything unavailable
+        was excluded from the score rather than counted against the repository.
+      </p>
+      <ul className="text-muted mt-2 list-disc space-y-1 pl-5 text-sm">
+        {limitations.map((limitation) => (
+          <li key={limitation}>{limitation}</li>
+        ))}
+      </ul>
+    </aside>
+  );
+}

--- a/src/components/category-card.tsx
+++ b/src/components/category-card.tsx
@@ -1,0 +1,164 @@
+import type { CategoryScore, Metric } from '@/types/analysis';
+
+import { FindingsList } from './findings';
+import { CategoryScoreBar, ConfidenceBadge } from './score-display';
+
+/**
+ * A category scorecard with its full methodology.
+ *
+ * The disclosure is a native `<details>` element: it works without JavaScript,
+ * is keyboard operable for free, and is announced correctly by screen readers.
+ * This is the "How was this calculated?" affordance the whole product is built
+ * around, so it should be the least fragile thing on the page.
+ */
+
+const UNKNOWN_REASON_TEXT: Record<string, string> = {
+  not_retrieved: 'Could not be retrieved',
+  insufficient_data: 'Insufficient data',
+  not_applicable: 'Not applicable',
+  requires_elevated_permissions: 'Unable to verify from public GitHub data',
+};
+
+function MetricValue({ metric }: { metric: Metric }) {
+  if (metric.value === null) {
+    const reason = metric.unknownReason
+      ? UNKNOWN_REASON_TEXT[metric.unknownReason]
+      : undefined;
+    return <span className="text-score-unknown">{reason ?? 'Unknown'}</span>;
+  }
+
+  return (
+    <span className="tabular-nums">
+      {String(metric.value)}
+      {metric.unit !== undefined && <span className="text-muted"> {metric.unit}</span>}
+    </span>
+  );
+}
+
+function MethodologyTable({ category }: { category: CategoryScore }) {
+  const { components } = category.explanation;
+  if (components.length === 0) return null;
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full min-w-[36rem] border-collapse text-left text-sm">
+        <caption className="sr-only">
+          Scoring components for {category.label}, with the weight, observation, and rule
+          applied to each
+        </caption>
+        <thead>
+          <tr className="border-border-subtle text-muted border-b text-xs uppercase">
+            <th scope="col" className="py-2 pr-4 font-medium">
+              Component
+            </th>
+            <th scope="col" className="py-2 pr-4 font-medium">
+              Score
+            </th>
+            <th scope="col" className="py-2 pr-4 font-medium">
+              Weight
+            </th>
+            <th scope="col" className="py-2 font-medium">
+              Observed
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {components.map((component) => (
+            <tr key={component.id} className="border-border-subtle border-b align-top">
+              <th scope="row" className="py-2 pr-4 font-medium">
+                {component.label}
+                <span className="text-muted mt-0.5 block text-xs font-normal">
+                  {component.rule}
+                </span>
+              </th>
+              <td className="py-2 pr-4 tabular-nums">
+                {component.score === null ? (
+                  <span className="text-score-unknown">Excluded</span>
+                ) : (
+                  component.score
+                )}
+              </td>
+              <td className="text-muted py-2 pr-4 tabular-nums">{component.weight}</td>
+              <td className="text-muted py-2">{component.observed}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+export function CategoryCard({ category }: { category: CategoryScore }) {
+  return (
+    <section
+      className="border-border-subtle bg-surface-raised rounded-lg border p-5"
+      aria-labelledby={`category-${category.key}`}
+    >
+      <div className="flex items-start justify-between gap-3">
+        <h2 id={`category-${category.key}`} className="text-lg font-semibold">
+          {category.label}
+        </h2>
+        <ConfidenceBadge confidence={category.confidence} />
+      </div>
+
+      <div className="mt-4">
+        <CategoryScoreBar score={category.score} label="Score" />
+      </div>
+
+      <p className="text-muted mt-4 text-sm">{category.explanation.summary}</p>
+
+      {category.findings.length > 0 && (
+        <div className="mt-5">
+          <h3 className="mb-2 text-sm font-medium">Findings</h3>
+          <FindingsList findings={category.findings} />
+        </div>
+      )}
+
+      <details className="group mt-5">
+        <summary className="text-accent cursor-pointer text-sm font-medium underline underline-offset-4">
+          How was this calculated?
+        </summary>
+
+        <div className="mt-4 flex flex-col gap-5">
+          <div>
+            <h3 className="mb-2 text-sm font-medium">Formula</h3>
+            <p className="text-muted font-mono text-xs break-words">
+              {category.explanation.formula}
+            </p>
+          </div>
+
+          <div>
+            <h3 className="mb-2 text-sm font-medium">Components and weights</h3>
+            <MethodologyTable category={category} />
+          </div>
+
+          <div>
+            <h3 className="mb-2 text-sm font-medium">Metrics examined</h3>
+            <dl className="grid gap-x-6 gap-y-1 text-sm sm:grid-cols-2">
+              {category.metrics.map((metric) => (
+                <div
+                  key={metric.id}
+                  className="border-border-subtle flex justify-between gap-4 border-b py-1"
+                >
+                  <dt className="text-muted">{metric.label}</dt>
+                  <dd className="text-right">
+                    <MetricValue metric={metric} />
+                  </dd>
+                </div>
+              ))}
+            </dl>
+          </div>
+
+          <div>
+            <h3 className="mb-2 text-sm font-medium">Limitations</h3>
+            <ul className="text-muted list-disc space-y-1 pl-5 text-sm">
+              {category.explanation.limitations.map((limitation) => (
+                <li key={limitation}>{limitation}</li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      </details>
+    </section>
+  );
+}

--- a/src/components/findings.tsx
+++ b/src/components/findings.tsx
@@ -1,0 +1,113 @@
+import type { Finding, Severity } from '@/types/analysis';
+
+/**
+ * Findings list.
+ *
+ * Severity is shown as a text badge rather than a coloured dot, so it reads
+ * identically in greyscale and to a screen reader. Every finding shows what
+ * was observed, why it matters, the raw metric behind it, and a link to the
+ * evidence on GitHub where one exists — that combination is what makes a
+ * finding auditable rather than an assertion.
+ */
+
+const SEVERITY_LABEL: Record<Severity, string> = {
+  high: 'High',
+  medium: 'Medium',
+  low: 'Low',
+  info: 'Info',
+};
+
+const SEVERITY_CLASS: Record<Severity, string> = {
+  high: 'border-severity-high text-severity-high',
+  medium: 'border-severity-medium text-severity-medium',
+  low: 'border-severity-low text-severity-low',
+  info: 'border-severity-info text-severity-info',
+};
+
+export function SeverityBadge({ severity }: { severity: Severity }) {
+  return (
+    <span
+      className={`inline-flex shrink-0 items-center rounded border px-2 py-0.5 text-xs font-medium ${SEVERITY_CLASS[severity]}`}
+    >
+      {SEVERITY_LABEL[severity]}
+    </span>
+  );
+}
+
+function MetricList({ metric }: { metric: Finding['metric'] }) {
+  const entries = Object.entries(metric);
+  if (entries.length === 0) return null;
+
+  return (
+    <dl className="text-muted flex flex-wrap gap-x-4 gap-y-1 text-xs">
+      {entries.map(([key, value]) => (
+        <div key={key} className="flex gap-1">
+          <dt className="font-medium">{humanize(key)}:</dt>
+          <dd className="tabular-nums">{value === null ? 'Unknown' : String(value)}</dd>
+        </div>
+      ))}
+    </dl>
+  );
+}
+
+export function FindingCard({ finding }: { finding: Finding }) {
+  return (
+    <li className="border-border-subtle bg-surface-raised rounded-lg border p-4">
+      <div className="flex items-start justify-between gap-3">
+        <h3 className="font-medium">{finding.title}</h3>
+        <SeverityBadge severity={finding.severity} />
+      </div>
+
+      <p className="text-muted mt-2 text-sm">{finding.explanation}</p>
+
+      <div className="mt-3">
+        <MetricList metric={finding.metric} />
+      </div>
+
+      <p className="mt-3 text-sm">
+        <span className="font-medium">Recommendation: </span>
+        <span className="text-muted">{finding.recommendation}</span>
+      </p>
+
+      <div className="text-muted mt-3 flex flex-wrap items-center gap-3 text-xs">
+        <span>Confidence: {finding.confidence}</span>
+        {finding.evidenceUrl !== undefined && (
+          <a
+            className="text-accent underline underline-offset-2"
+            href={finding.evidenceUrl}
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            View evidence on GitHub
+          </a>
+        )}
+      </div>
+    </li>
+  );
+}
+
+export function FindingsList({
+  findings,
+  emptyMessage = 'No findings were raised for this category.',
+}: {
+  findings: Finding[];
+  emptyMessage?: string;
+}) {
+  if (findings.length === 0) {
+    return <p className="text-muted text-sm">{emptyMessage}</p>;
+  }
+
+  return (
+    <ul className="flex flex-col gap-3">
+      {findings.map((finding) => (
+        <FindingCard key={finding.id} finding={finding} />
+      ))}
+    </ul>
+  );
+}
+
+/** `staleIssues` → `Stale issues`. */
+function humanize(key: string): string {
+  const spaced = key.replace(/([A-Z])/g, ' $1').toLowerCase();
+  return spaced.charAt(0).toUpperCase() + spaced.slice(1);
+}

--- a/src/components/repository-search.tsx
+++ b/src/components/repository-search.tsx
@@ -1,0 +1,84 @@
+'use client';
+
+import Link from 'next/link';
+import { useActionState } from 'react';
+
+import { analyzeRepository, type SearchState } from '@/app/actions';
+
+const EXAMPLES = [
+  { label: 'facebook/react', href: '/r/facebook/react' },
+  { label: 'vercel/next.js', href: '/r/vercel/next.js' },
+  { label: 'prisma/prisma', href: '/r/prisma/prisma' },
+];
+
+const INITIAL: SearchState = {};
+
+/**
+ * The repository input.
+ *
+ * A real `<form>` posting to a server action, so it works before hydration and
+ * with JavaScript disabled. The error is wired to the input with
+ * `aria-describedby` and announced through a live region, so a screen reader
+ * user learns about a rejected value without having to go looking for it.
+ */
+export function RepositorySearch() {
+  const [state, formAction, pending] = useActionState(analyzeRepository, INITIAL);
+  const errorId = 'repository-error';
+
+  return (
+    <div className="flex flex-col gap-4">
+      <form action={formAction} className="flex flex-col gap-3 sm:flex-row">
+        <div className="flex-1">
+          <label htmlFor="repository" className="sr-only">
+            GitHub repository, as owner/name or a GitHub URL
+          </label>
+          <input
+            id="repository"
+            name="repository"
+            type="text"
+            autoComplete="off"
+            spellCheck={false}
+            defaultValue={state.value ?? ''}
+            placeholder="owner/repository"
+            aria-invalid={state.error !== undefined}
+            aria-describedby={state.error !== undefined ? errorId : undefined}
+            className="border-border-strong bg-surface-raised placeholder:text-muted w-full rounded-md border px-4 py-3 text-base"
+          />
+        </div>
+
+        <button
+          type="submit"
+          disabled={pending}
+          className="bg-accent text-accent-contrast rounded-md px-6 py-3 font-medium disabled:opacity-60"
+        >
+          {pending ? 'Analyzing…' : 'Analyze'}
+        </button>
+      </form>
+
+      {/* Always rendered so the live region exists before it has content. */}
+      <p
+        id={errorId}
+        role="status"
+        aria-live="polite"
+        className="text-severity-high text-sm"
+      >
+        {state.error ?? ''}
+      </p>
+
+      <p className="text-muted text-sm">
+        Examples:{' '}
+        {EXAMPLES.map((example, index) => (
+          <span key={example.href}>
+            {index > 0 && ', '}
+            <Link
+              href={example.href}
+              className="text-accent underline underline-offset-4"
+            >
+              {example.label}
+            </Link>
+          </span>
+        ))}
+      </p>
+    </div>
+  );
+}

--- a/src/components/score-display.tsx
+++ b/src/components/score-display.tsx
@@ -1,0 +1,154 @@
+import type { Confidence } from '@/types/analysis';
+
+/**
+ * Score presentation.
+ *
+ * Two rules hold everywhere in this file:
+ *
+ * 1. **A null score is never rendered as a number.** It renders as
+ *    "Insufficient data" with the reason available, because showing `0` or a
+ *    dash would read as "scored badly" rather than "not measured".
+ * 2. **Colour never carries meaning alone.** Every score is accompanied by the
+ *    number and a text band, so the information survives greyscale, colour
+ *    blindness, and a screen reader.
+ */
+
+export type ScoreBand = 'strong' | 'moderate' | 'weak' | 'unknown';
+
+export function bandFor(score: number | null): ScoreBand {
+  if (score === null) return 'unknown';
+  if (score >= 80) return 'strong';
+  if (score >= 55) return 'moderate';
+  return 'weak';
+}
+
+/** The text label that accompanies every score. */
+export function bandLabel(score: number | null): string {
+  switch (bandFor(score)) {
+    case 'strong':
+      return 'Strong';
+    case 'moderate':
+      return 'Moderate';
+    case 'weak':
+      return 'Needs attention';
+    case 'unknown':
+      return 'Insufficient data';
+  }
+}
+
+const BAND_TEXT: Record<ScoreBand, string> = {
+  strong: 'text-score-strong',
+  moderate: 'text-score-moderate',
+  weak: 'text-score-weak',
+  unknown: 'text-score-unknown',
+};
+
+const CONFIDENCE_LABEL: Record<Confidence, string> = {
+  high: 'High confidence',
+  medium: 'Medium confidence',
+  low: 'Low confidence',
+};
+
+export function ConfidenceBadge({ confidence }: { confidence: Confidence }) {
+  return (
+    <span className="border-border-subtle text-muted inline-flex items-center rounded-full border px-2 py-0.5 text-xs">
+      {CONFIDENCE_LABEL[confidence]}
+    </span>
+  );
+}
+
+/**
+ * The headline overall score.
+ *
+ * The `/ 100` is rendered as a separate, quieter element so a screen reader
+ * announces "86 out of 100" rather than "86100".
+ */
+export function OverallScore({
+  score,
+  confidence,
+}: {
+  score: number | null;
+  confidence: Confidence;
+}) {
+  const band = bandFor(score);
+
+  return (
+    <div className="flex flex-col gap-2">
+      <p className="text-muted text-sm font-medium tracking-wide uppercase">
+        Engineering health
+      </p>
+
+      {score === null ? (
+        <p className={`text-3xl font-semibold ${BAND_TEXT.unknown}`}>Insufficient data</p>
+      ) : (
+        <p className="flex items-baseline gap-2">
+          <span className={`text-6xl font-semibold tabular-nums ${BAND_TEXT[band]}`}>
+            {score}
+          </span>
+          <span className="text-muted text-2xl" aria-hidden="true">
+            / 100
+          </span>
+          <span className="sr-only">out of 100</span>
+        </p>
+      )}
+
+      <div className="flex flex-wrap items-center gap-2">
+        <span className={`text-sm font-medium ${BAND_TEXT[band]}`}>
+          {bandLabel(score)}
+        </span>
+        <ConfidenceBadge confidence={confidence} />
+      </div>
+    </div>
+  );
+}
+
+/**
+ * A category score as a labelled bar.
+ *
+ * The bar is decorative — `aria-hidden` — because the number and band label
+ * beside it already carry the value. A screen reader reading a progressbar
+ * role here would just repeat what it already announced.
+ */
+export function CategoryScoreBar({
+  score,
+  label,
+}: {
+  score: number | null;
+  label: string;
+}) {
+  const band = bandFor(score);
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      <div className="flex items-baseline justify-between gap-2">
+        <span className="text-sm font-medium">{label}</span>
+        {score === null ? (
+          <span className={`text-sm ${BAND_TEXT.unknown}`}>Insufficient data</span>
+        ) : (
+          <span className={`text-sm font-semibold tabular-nums ${BAND_TEXT[band]}`}>
+            {score}
+            <span className="sr-only"> out of 100</span>
+          </span>
+        )}
+      </div>
+
+      <div
+        className="bg-surface border-border-subtle h-1.5 w-full overflow-hidden rounded-full border"
+        aria-hidden="true"
+      >
+        {score !== null && (
+          <div
+            className={`h-full rounded-full ${
+              band === 'strong'
+                ? 'bg-score-strong'
+                : band === 'moderate'
+                  ? 'bg-score-moderate'
+                  : 'bg-score-weak'
+            }`}
+            style={{ width: `${score}%` }}
+          />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/lib/github/client.ts
+++ b/src/lib/github/client.ts
@@ -22,6 +22,12 @@ const DEFAULT_BUDGET = 40;
  */
 const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
 
+/**
+ * Redirect hops allowed per request. GitHub's canonicalization is one hop;
+ * more than a few means something is wrong.
+ */
+const MAX_REDIRECTS = 3;
+
 /** GitHub asks for an explicit API version and a descriptive user agent. */
 const BASE_HEADERS: Record<string, string> = {
   Accept: 'application/vnd.github+json',
@@ -64,6 +70,11 @@ export interface RequestOptions {
   etag?: string | null;
   /** Override the default Accept header, e.g. for raw file contents. */
   accept?: string;
+  /**
+   * How to read the body. `text` is needed for raw file contents, which
+   * GitHub returns as the file itself rather than as JSON.
+   */
+  parse?: 'json' | 'text';
   signal?: AbortSignal;
 }
 
@@ -197,10 +208,12 @@ export class GitHubClient {
       );
     }
 
-    const url = this.#buildUrl(options.path, options.searchParams);
+    let url = this.#buildUrl(options.path, options.searchParams);
+    let redirects = 0;
+    let attempt = 0;
     let lastError: unknown;
 
-    for (let attempt = 0; attempt <= this.#maxRetries; attempt += 1) {
+    for (;;) {
       const timeout = AbortSignal.timeout(this.#timeoutMs);
       const signal = options.signal
         ? AbortSignal.any([options.signal, timeout])
@@ -212,8 +225,9 @@ export class GitHubClient {
           method: 'GET',
           headers: this.#headers(options),
           signal,
-          // A redirect off api.github.com would defeat the SSRF boundary, so
-          // it is surfaced as an error rather than followed.
+          // Redirects are followed manually so each hop's target can be
+          // checked against the API origin. Letting fetch follow them
+          // automatically would allow a redirect off api.github.com.
           redirect: 'manual',
         });
       } catch (cause) {
@@ -228,6 +242,7 @@ export class GitHubClient {
         lastError = cause;
         if (attempt < this.#maxRetries) {
           await this.#sleep(this.#backoffMs(attempt));
+          attempt += 1;
           continue;
         }
 
@@ -253,16 +268,18 @@ export class GitHubClient {
       }
 
       if (REDIRECT_STATUSES.has(response.status)) {
-        throw new GitHubError('unexpected', 'GitHub redirected the request.', {
-          status: response.status,
-          resource: options.path,
-        });
+        url = this.#resolveRedirect(response, url, options.path, redirects);
+        redirects += 1;
+        continue;
       }
 
       if (response.ok) {
         let data: T;
         try {
-          data = (await response.json()) as T;
+          data =
+            options.parse === 'text'
+              ? ((await response.text()) as T)
+              : ((await response.json()) as T);
         } catch (cause) {
           throw new GitHubError('invalid_response', 'GitHub returned malformed JSON.', {
             status: response.status,
@@ -282,6 +299,7 @@ export class GitHubClient {
       // Retry server errors only. A 4xx will not become a 2xx by asking again.
       if (response.status >= 500 && attempt < this.#maxRetries) {
         await this.#sleep(this.#backoffMs(attempt));
+        attempt += 1;
         continue;
       }
 
@@ -293,6 +311,61 @@ export class GitHubClient {
       resource: options.path,
       cause: lastError,
     });
+  }
+
+  /**
+   * Validates a redirect target and returns it.
+   *
+   * GitHub legitimately redirects `repos/{owner}/{name}` to its canonical
+   * `repositories/{id}` URL for any repository that has ever been renamed or
+   * transferred — `facebook/react` among them. Refusing all redirects made
+   * those repositories unanalyzable.
+   *
+   * The SSRF concern was never same-origin canonicalization; it is a redirect
+   * to a *different* host. So each hop is resolved and its origin checked
+   * against the API base, and the hop count is bounded so a redirect loop
+   * cannot spin.
+   */
+  #resolveRedirect(
+    response: Response,
+    currentUrl: string,
+    resource: string,
+    redirectsSoFar: number,
+  ): string {
+    if (redirectsSoFar >= MAX_REDIRECTS) {
+      throw new GitHubError('unexpected', 'GitHub redirected too many times.', {
+        status: response.status,
+        resource,
+      });
+    }
+
+    const location = response.headers.get('location');
+    if (location === null || location === '') {
+      throw new GitHubError('unexpected', 'GitHub redirected without a target.', {
+        status: response.status,
+        resource,
+      });
+    }
+
+    let target: URL;
+    try {
+      target = new URL(location, currentUrl);
+    } catch {
+      throw new GitHubError('unexpected', 'GitHub redirected to an invalid target.', {
+        status: response.status,
+        resource,
+      });
+    }
+
+    if (target.origin !== API_BASE) {
+      throw new GitHubError(
+        'unexpected',
+        'Refusing to follow a redirect away from the GitHub API.',
+        { status: response.status, resource },
+      );
+    }
+
+    return target.toString();
   }
 
   #toError(response: Response, resource: string): GitHubError {

--- a/src/lib/github/collector.ts
+++ b/src/lib/github/collector.ts
@@ -143,15 +143,121 @@ export async function collectSnapshot(
   const repository = repositorySchema.parse(repositoryResponse.data);
   const identity = normalizeIdentity(repository);
 
-  const rootEntries =
-    (await collector.attempt('contents', () =>
-      listDirectory(client, `${base}/contents`),
-    )) ?? [];
+  // Everything below depends only on the repository call above, so the
+  // independent collections run concurrently. Sequentially this took ~14s on a
+  // large repository; concurrently it is a few seconds. The request budget is
+  // still enforced per request, so concurrency cannot overspend it.
+  const [
+    rootEntries,
+    githubDirEntries,
+    workflowFiles,
+    issuesResult,
+    pullsResult,
+    releasesResult,
+    tagCount,
+    contributorCount,
+    weeklyCommits,
+    workflows,
+    runs,
+    commitStatus,
+    branchProtected,
+  ] = await Promise.all([
+    collector
+      .attempt('contents', () => listDirectory(client, `${base}/contents`))
+      .then((entries) => entries ?? []),
 
-  const githubDirEntries =
-    (await collector.attempt('contents/.github', () =>
-      listDirectory(client, `${base}/contents/.github`),
-    )) ?? [];
+    collector
+      .attempt('contents/.github', () =>
+        listDirectory(client, `${base}/contents/.github`),
+      )
+      .then((entries) => entries ?? []),
+
+    collector
+      .attempt('contents/.github/workflows', () =>
+        listDirectory(client, `${base}/contents/.github/workflows`),
+      )
+      .then((entries) => entries ?? []),
+
+    collector.attempt('issues', () =>
+      client.paginate<unknown>({
+        path: `${base}/issues`,
+        searchParams: { state: 'all', sort: 'created', direction: 'desc' },
+        maxItems: SAMPLE_LIMITS.issues,
+      }),
+    ),
+
+    collector.attempt('pulls', () =>
+      client.paginate<unknown>({
+        path: `${base}/pulls`,
+        searchParams: { state: 'all', sort: 'created', direction: 'desc' },
+        maxItems: SAMPLE_LIMITS.pullRequests,
+      }),
+    ),
+
+    collector.attempt('releases', () =>
+      client.paginate<unknown>({
+        path: `${base}/releases`,
+        maxItems: SAMPLE_LIMITS.releases,
+      }),
+    ),
+
+    collector.attempt('tags', () => countViaPagination(client, `${base}/tags`)),
+
+    collector.attempt('contributors', () =>
+      countViaPagination(client, `${base}/contributors`),
+    ),
+
+    collector.attempt('stats/commit_activity', async () => {
+      const response = await client.request<unknown>({
+        path: `${base}/stats/commit_activity`,
+      });
+      // GitHub answers 202 with no body while it computes statistics. That is
+      // "not yet known", which must stay null rather than becoming zero commits.
+      if (response.status === 202 || response.data === null) return null;
+
+      const parsed = commitActivitySchema.safeParse(response.data);
+      return parsed.success ? parsed.data.map((week) => week.total) : null;
+    }),
+
+    collector.attempt('actions/workflows', async () => {
+      const response = await client.request<unknown>({
+        path: `${base}/actions/workflows`,
+      });
+      return workflowListSchema.safeParse(response.data);
+    }),
+
+    collector.attempt('actions/runs', async () => {
+      const response = await client.request<unknown>({
+        path: `${base}/actions/runs`,
+        searchParams: {
+          branch: identity.defaultBranch,
+          per_page: SAMPLE_LIMITS.workflowRuns,
+        },
+      });
+      return workflowRunListSchema.safeParse(response.data);
+    }),
+
+    collector.attempt('commit status', async () => {
+      const response = await client.request<unknown>({
+        path: `${base}/commits/${identity.defaultBranch}/status`,
+      });
+      const parsed = combinedStatusSchema.safeParse(response.data);
+      if (!parsed.success) return null;
+      // `pending` with no checks at all means there is no CI on this commit,
+      // which is different from a check that is still running.
+      return parsed.data.total_count === 0 ? 'none' : parsed.data.state;
+    }),
+
+    // Branch protection requires elevated permissions on most repositories.
+    // A 403 or 404 here is expected and must stay `null` — "unable to verify" —
+    // rather than being recorded as "not protected".
+    collector.attempt('branch protection', async () => {
+      await client.request<unknown>({
+        path: `${base}/branches/${identity.defaultBranch}/protection`,
+      });
+      return true;
+    }),
+  ]);
 
   const hasIssueTemplates = githubDirEntries.some(
     (entry) => entry.type === 'dir' && entry.name.toLowerCase() === 'issue_template',
@@ -164,104 +270,21 @@ export async function collectSnapshot(
 
   // Workflow file contents are read as text to detect security scanning steps.
   // Nothing is executed or evaluated — see SECURITY.md.
-  const workflowFiles =
-    (await collector.attempt('contents/.github/workflows', () =>
-      listDirectory(client, `${base}/contents/.github/workflows`),
-    )) ?? [];
-
-  const workflowContents: string[] = [];
-  for (const entry of workflowFiles.slice(0, SAMPLE_LIMITS.workflowFiles)) {
-    const content = await collector.attempt(`workflow:${entry.name}`, async () => {
-      const response = await client.request<unknown>({
-        path: `${base}/contents/${entry.path}`,
-        accept: 'application/vnd.github.raw+json',
-      });
-      return typeof response.data === 'string'
-        ? response.data
-        : JSON.stringify(response.data);
-    });
-    if (content !== null) workflowContents.push(content);
-  }
-
-  const issuesResult = await collector.attempt('issues', () =>
-    client.paginate<unknown>({
-      path: `${base}/issues`,
-      searchParams: { state: 'all', sort: 'created', direction: 'desc' },
-      maxItems: SAMPLE_LIMITS.issues,
-    }),
-  );
-
-  const pullsResult = await collector.attempt('pulls', () =>
-    client.paginate<unknown>({
-      path: `${base}/pulls`,
-      searchParams: { state: 'all', sort: 'created', direction: 'desc' },
-      maxItems: SAMPLE_LIMITS.pullRequests,
-    }),
-  );
-
-  const releasesResult = await collector.attempt('releases', () =>
-    client.paginate<unknown>({
-      path: `${base}/releases`,
-      maxItems: SAMPLE_LIMITS.releases,
-    }),
-  );
-
-  const tagCount = await collector.attempt('tags', () =>
-    countViaPagination(client, `${base}/tags`),
-  );
-
-  const contributorCount = await collector.attempt('contributors', () =>
-    countViaPagination(client, `${base}/contributors`),
-  );
-
-  const weeklyCommits = await collector.attempt('stats/commit_activity', async () => {
-    const response = await client.request<unknown>({
-      path: `${base}/stats/commit_activity`,
-    });
-    // GitHub answers 202 with no body while it computes statistics. That is
-    // "not yet known", which must stay null rather than becoming zero commits.
-    if (response.status === 202 || response.data === null) return null;
-
-    const parsed = commitActivitySchema.safeParse(response.data);
-    return parsed.success ? parsed.data.map((week) => week.total) : null;
-  });
-
-  const workflows = await collector.attempt('actions/workflows', async () => {
-    const response = await client.request<unknown>({ path: `${base}/actions/workflows` });
-    return workflowListSchema.safeParse(response.data);
-  });
-
-  const runs = await collector.attempt('actions/runs', async () => {
-    const response = await client.request<unknown>({
-      path: `${base}/actions/runs`,
-      searchParams: {
-        branch: identity.defaultBranch,
-        per_page: SAMPLE_LIMITS.workflowRuns,
-      },
-    });
-    return workflowRunListSchema.safeParse(response.data);
-  });
-
-  const commitStatus = await collector.attempt('commit status', async () => {
-    const response = await client.request<unknown>({
-      path: `${base}/commits/${identity.defaultBranch}/status`,
-    });
-    const parsed = combinedStatusSchema.safeParse(response.data);
-    if (!parsed.success) return null;
-    // `pending` with no checks at all means there is no CI on this commit,
-    // which is different from a check that is still running.
-    return parsed.data.total_count === 0 ? 'none' : parsed.data.state;
-  });
-
-  // Branch protection requires elevated permissions on most repositories.
-  // A 403 here is expected and must stay `null` — "unable to verify" — rather
-  // than being recorded as "not protected".
-  const branchProtected = await collector.attempt('branch protection', async () => {
-    await client.request<unknown>({
-      path: `${base}/branches/${identity.defaultBranch}/protection`,
-    });
-    return true;
-  });
+  const workflowContents = (
+    await Promise.all(
+      workflowFiles.slice(0, SAMPLE_LIMITS.workflowFiles).map((entry) =>
+        collector.attempt(`workflow:${entry.name}`, async () => {
+          // Requested as raw text: GitHub returns the file itself, not JSON.
+          const response = await client.request<string>({
+            path: `${base}/contents/${entry.path}`,
+            accept: 'application/vnd.github.raw',
+            parse: 'text',
+          });
+          return response.data ?? '';
+        }),
+      ),
+    )
+  ).filter((content): content is string => content !== null);
 
   const issueRaws = (issuesResult?.items ?? [])
     .map((item) => issueSchema.safeParse(item))

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,0 +1,67 @@
+import { NextResponse, type NextRequest } from 'next/server';
+
+/**
+ * Per-request Content Security Policy with a nonce.
+ *
+ * Next.js streams Suspense boundaries by flushing inline `<script>` tags, so a
+ * policy of `script-src 'self'` silently breaks streaming: the HTML is correct
+ * but the browser refuses to run the scripts that swap a fallback for its
+ * content, and the page sits on its loading state forever. That bug is only
+ * visible in a real browser, which is why it survived until one was pointed at
+ * the app.
+ *
+ * The alternatives were `'unsafe-inline'`, which defeats most of the point of
+ * having a script CSP, or a per-request nonce. This takes the nonce.
+ *
+ * The cost is real and worth stating: nonces are injected during rendering, so
+ * every page must render dynamically. RepoSignal gives up prerendering its
+ * homepage to get a strict script policy. For an application whose entire
+ * subject is engineering diligence, that is the right side of the trade.
+ *
+ * `style-src` keeps `'unsafe-inline'`: inline *style attributes* are used for
+ * the score bars, and CSP has no nonce mechanism for attributes. Inline styles
+ * are a far weaker vector than inline scripts.
+ */
+export function proxy(request: NextRequest) {
+  const nonce = Buffer.from(crypto.randomUUID()).toString('base64');
+  const isDev = process.env.NODE_ENV === 'development';
+
+  const csp = [
+    "default-src 'self'",
+    // `strict-dynamic` lets the nonced bootstrap script load the rest of the
+    // bundle, so no host allowlist is needed. `unsafe-eval` is required only in
+    // development, where React uses eval to rebuild server stack traces.
+    `script-src 'self' 'nonce-${nonce}' 'strict-dynamic'${isDev ? " 'unsafe-eval'" : ''}`,
+    "style-src 'self' 'unsafe-inline'",
+    "img-src 'self' data: https://avatars.githubusercontent.com",
+    "font-src 'self'",
+    "connect-src 'self'",
+    "object-src 'none'",
+    "base-uri 'self'",
+    "form-action 'self'",
+    "frame-ancestors 'none'",
+    'upgrade-insecure-requests',
+  ].join('; ');
+
+  const requestHeaders = new Headers(request.headers);
+  requestHeaders.set('x-nonce', nonce);
+  requestHeaders.set('Content-Security-Policy', csp);
+
+  const response = NextResponse.next({ request: { headers: requestHeaders } });
+  response.headers.set('Content-Security-Policy', csp);
+
+  return response;
+}
+
+export const config = {
+  matcher: [
+    {
+      // Static assets and prefetches need no policy of their own.
+      source: '/((?!_next/static|_next/image|favicon.ico).*)',
+      missing: [
+        { type: 'header', key: 'next-router-prefetch' },
+        { type: 'header', key: 'purpose', value: 'prefetch' },
+      ],
+    },
+  ],
+};

--- a/tests/unit/github/client.test.ts
+++ b/tests/unit/github/client.test.ts
@@ -108,12 +108,74 @@ describe('GitHubClient request construction', () => {
     expect(new Headers(calls[0]?.init.headers).get('if-none-match')).toBe('W/"abc"');
   });
 
-  it('does not follow redirects, which would escape the API host', async () => {
-    const { client } = makeClient([
-      new Response(null, { status: 302, headers: { location: 'https://evil.com' } }),
-    ]);
-    await expect(client.request({ path: 'repos/a/b' })).rejects.toMatchObject({
-      kind: 'unexpected',
+  describe('redirects', () => {
+    it('follows a same-origin redirect to GitHub’s canonical URL', async () => {
+      // GitHub 301s `repos/{owner}/{name}` to `repositories/{id}` for any
+      // repository that has ever been renamed or transferred — facebook/react
+      // among them. Refusing this made those repositories unanalyzable.
+      const { client, calls } = makeClient([
+        new Response(null, {
+          status: 301,
+          headers: { location: 'https://api.github.com/repositories/10270250' },
+        }),
+        json({ id: 10270250 }),
+      ]);
+
+      const response = await client.request<{ id: number }>({
+        path: 'repos/facebook/react',
+      });
+
+      expect(response.data).toEqual({ id: 10270250 });
+      expect(calls[1]?.url).toBe('https://api.github.com/repositories/10270250');
+    });
+
+    it('counts a redirected request once against the budget', async () => {
+      const { client } = makeClient([
+        new Response(null, {
+          status: 301,
+          headers: { location: 'https://api.github.com/repositories/1' },
+        }),
+        json({ id: 1 }),
+      ]);
+
+      await client.request({ path: 'repos/a/b' });
+      expect(client.budget.spent).toBe(1);
+    });
+
+    it.each([
+      ['a different host', 'https://evil.com/repos/a/b'],
+      ['a lookalike host', 'https://api.github.com.evil.com/repos/a/b'],
+      ['a non-API GitHub host', 'https://github.com/a/b'],
+    ])('refuses to follow a redirect to %s', async (_label, location) => {
+      const { client } = makeClient([
+        new Response(null, { status: 302, headers: { location } }),
+      ]);
+
+      await expect(client.request({ path: 'repos/a/b' })).rejects.toMatchObject({
+        kind: 'unexpected',
+      });
+    });
+
+    it('rejects a redirect with no target', async () => {
+      const { client } = makeClient([new Response(null, { status: 301 })]);
+      await expect(client.request({ path: 'repos/a/b' })).rejects.toMatchObject({
+        kind: 'unexpected',
+      });
+    });
+
+    it('stops rather than looping forever', async () => {
+      const { client, calls } = makeClient([
+        new Response(null, {
+          status: 301,
+          headers: { location: 'https://api.github.com/loop' },
+        }),
+      ]);
+
+      await expect(client.request({ path: 'repos/a/b' })).rejects.toMatchObject({
+        kind: 'unexpected',
+      });
+      // Bounded: the initial request plus the allowed hops, then it gives up.
+      expect(calls.length).toBeLessThanOrEqual(5);
     });
   });
 });


### PR DESCRIPTION
## Summary

The homepage, the `/r/[owner]/[repository]` report, and the failure states — wired to the real analysis service. RepoSignal now works end to end.

Closes #20, closes #22

## The report

Renders `AnalysisResult` and calculates nothing. Every category exposes **"How was this calculated?"** showing components, weights, thresholds, observations, metrics, and limitations.

That disclosure is a native `<details>` element rather than a state-driven component: it works before hydration, is keyboard operable, and is announced correctly by screen readers without any ARIA of my own. The single most important affordance in the product should also be the least fragile thing on the page.

Null scores render as **"Insufficient data"**, never `0` and never a bare dash. Excluded categories are listed with their reason and a note that the weight was redistributed. Score is never carried by colour alone — every score has a number and a text band.

## Three bugs found by pointing a real browser and the live API at this

None of these could have been caught by the existing tests, which is the point worth recording.

### 1. The CSP blocked Next's streaming

Next flushes Suspense boundaries through **inline scripts**. With `script-src 'self'`, the browser refused them, so every analysis sat on its loading state forever — while the streamed HTML underneath was completely correct. The server logs said `analysis_completed score=86`; the page said "Analyzing repository…".

Fixed with a per-request nonce in `src/proxy.ts` using `'strict-dynamic'`.

**The cost is real and worth stating explicitly:** nonces are injected at render time, so every route now renders dynamically. The homepage gives up prerendering to get a strict script policy. For an application whose subject is engineering diligence, that is the right side of the trade — but it is a trade, not a free win.

`style-src` keeps `'unsafe-inline'` because score bars use inline style *attributes*, for which CSP has no nonce mechanism. Inline styles are a far weaker vector than inline scripts.

### 2. The client refused all redirects

GitHub 301s `repos/{owner}/{name}` → `repositories/{id}` for any repository that has ever been renamed or transferred. `facebook/react` is one — it now resolves to **`react/react`**. Refusing all redirects made those repositories unanalyzable.

Redirects are now followed **only when the target origin is `api.github.com`**, bounded to three hops. The SSRF concern was never same-origin canonicalization; it is a redirect to another host.

As a side note, this is a nice validation of keying repository identity on the numeric id: the rename resolved cleanly instead of forking history.

### 3. Workflow contents were parsed as JSON

They were requested as `raw` but read with `.json()`, so every security-scanner detection failed with `invalid_response`. The client now takes a `parse: 'json' | 'text'` option.

## Performance

The collector awaited its endpoints sequentially — **14.5s** on facebook/react. The independent collections now run concurrently: same 22 requests, same score, **4.1s**.

## Also

`npm run analyze -- owner/repo` runs the real pipeline from the command line, which is how the numbers below were produced.

```
react/react     86/100  22 requests  4117ms
prisma/prisma   91/100  22 requests  2972ms
```

## Testing

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test` — 397 passing
- [x] `npm run build`
- [x] Verified in a real browser at 375px and 1280px, light and dark
- [x] Security headers verified on the response, including the per-request nonce

Component and E2E tests follow in #23 and #25 — this PR is the implementation plus the bug fixes its verification surfaced.

## Risks

Every route is now dynamic. For this application that is nearly free (the analysis route was already dynamic and the homepage is small), but it does mean no CDN-cached HTML for the homepage.

## Checklist

- [x] Scope matches the linked issues
- [x] Tests cover the new behavior (the three bug fixes have regression tests)
- [x] No scoring rules changed, so no version bump required
- [x] No secrets, tokens, or personal data added to the repository or logs
- [x] Documentation updated where behavior changed