### PR TITLE
docs: deploy to production and document the deployment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ analysis records the `scoringVersion` it was produced under.
 
 ### Added
 
+- Production deployment at https://reposignal-lovat.vercel.app
+
 - Distribution charts for open issue age, open pull request age, and commit
   activity — server-rendered SVG with an equivalent table for assistive
   technology, omitted entirely where there is too little data to draw one

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 [![CI](https://github.com/mateoosoriodelhonte/reposignal/actions/workflows/ci.yml/badge.svg)](https://github.com/mateoosoriodelhonte/reposignal/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
+**[Try it →](https://reposignal-lovat.vercel.app)** · [Scoring methodology](docs/SCORING.md) · [Architecture](ARCHITECTURE.md)
+
 RepoSignal takes a repository like `facebook/react` and reports how the project
 is actually being engineered — activity, pull request flow, issue backlog, CI,
 documentation, hygiene, and security practices — with every number traceable to
@@ -13,6 +15,12 @@ the public GitHub data it came from.
 ![A RepoSignal analysis of react/react, showing an overall score of 86 out of 100, seven category scores, and a banner explaining that branch protection could not be retrieved](docs/images/analysis.png)
 
 ---
+
+> **Live demo:** [reposignal-lovat.vercel.app](https://reposignal-lovat.vercel.app)
+>
+> The demo runs without a GitHub token, so it shares GitHub's unauthenticated
+> rate limit and may be temporarily unavailable under load. Running it locally
+> with a token — which needs no scopes — gives 5,000 requests an hour.
 
 ## Why this exists
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,0 +1,78 @@
+# Deployment
+
+RepoSignal is deployed on Vercel at
+[reposignal-lovat.vercel.app](https://reposignal-lovat.vercel.app).
+
+## Current configuration
+
+| Setting               | Value       | Notes                                 |
+| --------------------- | ----------- | ------------------------------------- |
+| Platform              | Vercel      | Free tier                             |
+| `GITHUB_TOKEN`        | **not set** | See below                             |
+| `DATABASE_URL`        | not set     | Falls back to the in-memory store     |
+| Deployment protection | disabled    | The demo has to be publicly reachable |
+
+## Why the demo has no GitHub token
+
+RepoSignal needs a token with **no scopes** — it reads only public data, and a
+token exists solely to raise the rate limit from 60 to 5,000 requests an hour.
+
+The token available on the machine that deployed this carries `repo` and
+`workflow` **write** scopes. Putting a credential that can write to
+repositories into a public web service, when the service needs none of that
+access, is not a trade worth making for a demo. So the deployment runs
+unauthenticated.
+
+The practical consequence: each analysis costs roughly 22 requests, so the
+demo can serve a couple of analyses per hour per edge region before GitHub
+rate limits it. Cached analyses are still served. Under load, visitors may see
+the rate-limit state — which is at least an honest demonstration of that
+error path.
+
+### Adding a token
+
+This is the one step that needs a human, because GitHub no longer allows
+creating personal access tokens through its API.
+
+1. Create a token at [github.com/settings/tokens](https://github.com/settings/tokens)
+   with **no scopes selected at all**.
+2. Add it to the project:
+
+   ```bash
+   vercel env add GITHUB_TOKEN production
+   # paste the token when prompted
+   vercel deploy --prod
+   ```
+
+That raises the demo to 5,000 requests an hour.
+
+## Adding a database
+
+Optional. Without `DATABASE_URL`, analyses are cached in memory, which on
+serverless means per-instance and short-lived — visitors mostly get fresh
+analyses.
+
+Any hosted PostgreSQL works. Set `DATABASE_URL` as a production environment
+variable, then run the migration against it:
+
+```bash
+DATABASE_URL="postgresql://..." npx prisma migrate deploy
+```
+
+## Verified after deployment
+
+- Homepage and analysis routes reachable without authentication
+- Real repositories analyzed correctly in production
+  (`prisma/prisma` 91, `vercel/next.js` 82)
+- Security headers present on the deployed origin, including the per-request
+  CSP nonce, and with `'unsafe-eval'` correctly absent in production
+- Partial-data path working: branch protection reported as unretrievable and
+  excluded rather than counted against the repository
+
+## Redeploying
+
+```bash
+vercel deploy --prod
+```
+
+The `main` branch is not auto-deployed; deployment is deliberate.


### PR DESCRIPTION
## Summary

RepoSignal is live at **[reposignal-lovat.vercel.app](https://reposignal-lovat.vercel.app)**, analyzing real repositories.

Closes #28

## The token decision

The deployment deliberately runs **without a GitHub token**.

RepoSignal needs a token with **no scopes at all** — it reads only public data, and a token exists solely to raise the rate limit from 60 to 5,000 requests an hour. The token available on the deploying machine carries `repo` and `workflow` **write** scopes.

Putting a credential that can write to repositories into a public web service, when the service needs none of that access, is not a trade worth making for a demo. The SSRF boundary is well tested, but "well tested" is not "proven", and least privilege says don't hand a public service write access it never uses.

The cost is stated rather than hidden, in the README and in `docs/DEPLOYMENT.md`: each analysis is roughly 22 requests, so the demo serves a couple of analyses an hour per edge region before GitHub rate limits it. Visitors under load will see the rate-limit state — which is at least an honest demonstration of that error path.

**Adding a token is the one step that needs a human**, because GitHub no longer allows creating personal access tokens through its API. `docs/DEPLOYMENT.md` has the exact two commands.

## Other deployment notes

- Vercel's SSO deployment protection was disabled **for this project only**. A demo nobody can reach is not a demo. Every URL initially returned 200 only because curl was following the redirect to Vercel's SSO page.
- `reposignal.vercel.app` belongs to an **unrelated project** — worth knowing before anyone links it. This project's domain is `reposignal-lovat.vercel.app`.
- No database is configured. The in-memory fallback works, which on serverless means caching is per-instance and short-lived.

## Verified in production

- [x] Homepage and analysis routes reachable without authentication
- [x] Real analyses: `prisma/prisma` 91, `vercel/next.js` 82
- [x] Security headers on the deployed origin, including the per-request CSP nonce
- [x] `'unsafe-eval'` correctly **absent** in production (present only in development, where React needs it)
- [x] Partial-data path: branch protection reported as unretrievable and excluded, not counted against the repository

```
content-security-policy: default-src 'self'; script-src 'self' 'nonce-…' 'strict-dynamic'; …
x-frame-options: DENY
x-content-type-options: nosniff
referrer-policy: strict-origin-when-cross-origin
```

## Risks

The demo will rate limit under any real traffic until a scopeless token is added. That is a deliberate, documented state rather than an oversight.

Deployment is manual (`vercel deploy --prod`) rather than wired to `main`, so shipping to production stays a decision.

## Checklist

- [x] Scope matches the linked issue
- [x] No scoring rules changed, so no version bump required
- [x] **No secrets committed** — `.env.local` and `.vercel/` are both gitignored, verified
- [x] Documentation updated (README demo link, docs/DEPLOYMENT.md, CHANGELOG)