### PR TITLE
chore: prepare the v1.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,22 +11,26 @@ analysis records the `scoringVersion` it was produced under.
 
 ## [Unreleased]
 
+## [1.0.0] - 2026-08-17
+
+Initial release. RepoSignal analyzes a public GitHub repository and reports
+engineering health across seven categories, with every score traceable to the
+public data it came from.
+
 ### Added
 
 - Production deployment at https://reposignal-lovat.vercel.app
-
 - Distribution charts for open issue age, open pull request age, and commit
   activity — server-rendered SVG with an equivalent table for assistive
   technology, omitted entirely where there is too little data to draw one
-
 - Complete documentation: `docs/SCORING.md` documenting every weight,
   threshold, and formula with its rationale and a worked example of weight
   redistribution; `ARCHITECTURE.md`; `docs/LOCAL_DEVELOPMENT.md`; README
   screenshots captured from a real analysis
-
 - Component tests for every UI state, integration tests covering the full
   pipeline with MSW, and a Playwright end-to-end suite running against bundled
-  fixtures — 451 tests in total
+  fixtures — 477 unit, integration, and component tests plus 22 end-to-end
+  specs
 - A malformed repository path now returns a real 404 status rather than
   rendering the not-found page under a 200
 - Analysis orchestration with a 15-minute cache freshness window, in-flight
@@ -62,3 +66,6 @@ analysis records the `scoringVersion` it was produced under.
   `RepositorySnapshot`) establishing the null-preserving contract
 - Security headers and Content Security Policy
 - Contribution, security, and code of conduct documentation
+
+[unreleased]: https://github.com/mateoosoriodelhonte/reposignal/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/mateoosoriodelhonte/reposignal/releases/tag/v1.0.0

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ npm run analyze -- facebook/react
 ## Testing
 
 ```bash
-npm test              # unit, integration, component — 454 tests
+npm test              # unit, integration, component — 477 tests
 npm run test:coverage # with coverage thresholds
 npm run test:e2e      # Playwright — 22 specs
 npm run lint

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reposignal",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "private": true,
   "description": "Evidence-backed engineering health analysis for public GitHub repositories.",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Finalizes `CHANGELOG.md` with a dated `1.0.0` entry and sets the package version.

Closes #29

## Scoring version stays 1.0.0

No scoring rule changed during release preparation. Bumping `SCORING_VERSION` would invalidate every cached analysis and misrepresent stored results as having been produced under different rules.

## Also

Corrects two test counts in the README and CHANGELOG that were accurate when written and went stale as the suite grew — 477, verified against an actual run rather than estimated.

## Release readiness

| Check | Result |
| --- | --- |
| `npm run format:check` | Clean |
| `npm run lint` | Clean |
| `npm run typecheck` | Clean |
| `npm test` | 477 passing |
| `npm run test:e2e` | 22 passing |
| `npm run build` | Succeeds |
| `npx prisma validate` | Valid |
| Internal documentation links | All resolve |
| Unreferenced modules | None |
| Secrets in tracked files | None — only a deliberately-fake test constant |
| Production deployment | Live and analyzing real repositories |

All 22 milestone issues are closed. Four `good first issue` opportunities (#42–#45) are open for contributors, each scoped with acceptance criteria and a starting point.

## Checklist

- [x] Scope matches the linked issue
- [x] No scoring rules changed, so no version bump required
- [x] No secrets, tokens, or personal data added to the repository or logs
- [x] Documentation updated where behavior changed