### PR TITLE
feat(normalize): recognize lockfiles from more ecosystems

### DIFF
--- a/src/lib/normalize/snapshot.ts
+++ b/src/lib/normalize/snapshot.ts
@@ -59,6 +59,13 @@ const LOCKFILES = new Set([
   'mix.lock',
   'pubspec.lock',
   'gradle.lockfile',
+  'package.resolved',
+  'deno.lock',
+  'manifest.toml',
+  'renv.lock',
+  'conan.lock',
+  'cabal.project.freeze',
+  'stack.yaml.lock',
 ]);
 
 /**

--- a/tests/unit/normalize/snapshot.test.ts
+++ b/tests/unit/normalize/snapshot.test.ts
@@ -452,6 +452,13 @@ describe('detectLockfiles', () => {
     ['go', 'go.sum'],
     ['bundler', 'Gemfile.lock'],
     ['composer', 'composer.lock'],
+    ['swift', 'Package.resolved'],
+    ['deno', 'deno.lock'],
+    ['julia', 'Manifest.toml'],
+    ['r', 'renv.lock'],
+    ['conan', 'conan.lock'],
+    ['cabal', 'cabal.project.freeze'],
+    ['stack', 'stack.yaml.lock'],
   ])('detects the %s lockfile', (_label, name) => {
     expect(detectLockfiles([file(name)])).toEqual([name]);
   });


### PR DESCRIPTION
## Summary
Extends the `LOCKFILES` normalization set to recognize canonical lockfiles from additional ecosystems (#42).

## Added Ecosystems & Canonical Lockfiles
- **Swift**: `Package.resolved` ([SwiftPM Documentation](https://www.swift.org/documentation/package-manager/))
- **Deno**: `deno.lock` ([Deno Documentation](https://docs.deno.com/runtime/fundamentals/configuration/#lockfile))
- **Julia**: `Manifest.toml` ([Julia Pkg Documentation](https://pkgdocs.julialang.org/v1/glossary/))
- **R**: `renv.lock` ([R renv Documentation](https://rstudio.github.io/renv/articles/lockfile.html))
- **Conan (C/C++)**: `conan.lock` ([Conan Documentation](https://docs.conan.io/2/tutorial/versioning/lockfiles.html))
- **Haskell**: `cabal.project.freeze` ([Cabal Documentation](https://cabal.readthedocs.io/en/stable/cabal-project.html#cabal-freeze)) and `stack.yaml.lock` ([Stack Documentation](https://docs.haskellstack.org/en/stable/lock_files/))

## Changes
- **`src/lib/normalize/snapshot.ts`**: Added the lowercase lockfile basenames to the `LOCKFILES` set.
- **`tests/unit/normalize/snapshot.test.ts`**: Added parameterized test cases for each added ecosystem.

Fixes #42