### PR TITLE
Recognize more security scanning tools in workflows

### DIFF
--- a/src/lib/normalize/snapshot.ts
+++ b/src/lib/normalize/snapshot.ts
@@ -85,6 +85,25 @@ const SECURITY_SCANNERS = [
   'pip-audit',
   'cargo audit',
   'bundler-audit',
+  'sonarsource/sonarcloud-github-action',
+  'sonarsource/sonarqube-scan-action',
+  'checkmarx/ast-github-action',
+  'veracode/veracode-uploadandscan-action',
+  'zaproxy/action-baseline',
+  'zaproxy/action-full-scan',
+  'securego/gosec',
+  'pycqa/bandit',
+  // Bare 'bandit' would fire on any repo that mentions multi-armed bandits, so
+  // the CLI is matched by its recursive-scan flag instead.
+  'bandit -r',
+  // RuboCop is a general linter; only an explicitly security-scoped run counts.
+  // Matches '--only Security' and narrower forms like '--only Security/Eval'.
+  'rubocop --only security',
+  'terrascan',
+  'tfsec',
+  'checkov',
+  'hadolint',
+  'grype',
 ];
 
 export function normalizeIdentity(raw: RawRepository): RepositoryIdentity {

--- a/tests/unit/normalize/snapshot.test.ts
+++ b/tests/unit/normalize/snapshot.test.ts
@@ -473,8 +473,46 @@ describe('detectSecurityScanners', () => {
     ['Semgrep', 'uses: semgrep/semgrep-action@v1'],
     ['npm audit', 'run: npm audit --audit-level=high'],
     ['gitleaks', 'uses: gitleaks/gitleaks-action@v2'],
+    ['SonarCloud', 'uses: SonarSource/sonarcloud-github-action@master'],
+    ['SonarQube', 'uses: SonarSource/sonarqube-scan-action@v4'],
+    ['Checkmarx', 'uses: Checkmarx/ast-github-action@main'],
+    ['Veracode', 'uses: veracode/veracode-uploadandscan-action@0.2.6'],
+    ['ZAP baseline', 'uses: zaproxy/action-baseline@v0.12.0'],
+    ['ZAP full scan', 'uses: zaproxy/action-full-scan@v0.10.0'],
+    ['gosec', 'uses: securego/gosec@master'],
+    ['bandit action', 'uses: PyCQA/bandit-action@v1'],
+    ['bandit CLI', 'run: bandit -r src/ -ll'],
+    ['RuboCop security cops', 'run: bundle exec rubocop --only Security'],
+    ['Terrascan', 'uses: tenable/terrascan-action@main'],
+    ['tfsec', 'uses: aquasecurity/tfsec-action@v1.0.0'],
+    ['Checkov', 'uses: bridgecrewio/checkov-action@master'],
+    ['hadolint', 'uses: hadolint/hadolint-action@v3.1.0'],
+    ['grype', 'uses: anchore/grype-action@v0.1.0'],
   ])('detects %s in workflow text', (_label, content) => {
     expect(detectSecurityScanners([content]).length).toBeGreaterThan(0);
+  });
+
+  it.each([
+    ['a multi-armed bandit experiment', 'run: python train.py --bandit-arms 8'],
+    ['an unscoped RuboCop lint run', 'run: bundle exec rubocop --parallel'],
+    ['a Sonar mention in prose', '# see sonarsource docs for setup notes'],
+  ])('does not fire on %s', (_label, content) => {
+    expect(detectSecurityScanners([content])).toEqual([]);
+  });
+
+  it('reports a narrower RuboCop security scope', () => {
+    expect(detectSecurityScanners(['run: rubocop --only Security/Eval'])).toEqual([
+      'rubocop --only security',
+    ]);
+  });
+
+  it('deduplicates a newly added scanner across several workflows', () => {
+    expect(
+      detectSecurityScanners([
+        'uses: hadolint/hadolint-action@v3.1.0',
+        'uses: hadolint/hadolint-action@v3.1.0 # second workflow',
+      ]),
+    ).toEqual(['hadolint']);
   });
 
   it('finds nothing in a workflow without scanning', () => {


### PR DESCRIPTION
Closes #43.

Adds 15 matchers to `SECURITY_SCANNERS` in `src/lib/normalize/snapshot.ts`, with a test case per addition. Detection stays plain lowercase substring matching against workflow text — nothing is parsed or evaluated, per the constraint documented on the list and in `SECURITY.md`.

### The matchers, and why each is specific enough

**Vendor SAST** — all are `org/repo` action slugs, so they can only appear in a `uses:` line or a link to one:

| Matcher | Tool |
|---|---|
| `sonarsource/sonarcloud-github-action` | SonarCloud |
| `sonarsource/sonarqube-scan-action` | SonarQube (the current successor action) |
| `checkmarx/ast-github-action` | Checkmarx One AST |
| `veracode/veracode-uploadandscan-action` | Veracode |
| `securego/gosec` | gosec (Go) |
| `pycqa/bandit` | bandit action (Python) |

**DAST** — `zaproxy/action-baseline` and `zaproxy/action-full-scan`. The issue named only the full scan, but the baseline scan is the more commonly used of the two and is equally a scan, so I added both.

**IaC / container / vulnerability** — `terrascan`, `tfsec`, `checkov`, `hadolint`, `grype`. These are bare tool names, which is safe here because each is a coined compound with no ordinary-English meaning; there is no plausible unrelated workflow text containing them. This matches how the list already treats `gitleaks` and `pip-audit`.

**Two matchers are deliberately narrower than the tool name**, because the bare name would have been too broad:

- **`bandit -r` rather than `bandit`.** "Bandit" is an ordinary word — a multi-armed bandit is standard ML vocabulary, and a workflow line like `run: python train.py --bandit-arms 8` would have been mis-scored as security scanning. The recursive-scan flag is how the CLI is actually invoked in CI.
- **`rubocop --only security` rather than `rubocop`.** The issue asked for "rubocop security cops", but RuboCop is a general-purpose linter — a bare match would mark *every* Ruby repo with a lint workflow as running security scanning. Scoping to the flag also picks up narrower forms like `--only Security/Eval` for free, since it is a prefix.

Both are covered by explicit negative tests.

### Two candidates from the issue I did **not** add

- **`syft`** — Syft generates an SBOM; it does not scan for anything. A repo that inventories its dependencies but never checks them against an advisory database would be scored as "has security scanning", which overstates it in the opposite direction from the bug being fixed. `grype` (which does consume advisories) is included. Happy to add `syft` if you consider SBOM generation in scope — it's a judgement call about what the signal means, so I'd rather you make it.
- **bare `checkmarx` / `veracode`** — the issue listed these as bare vendor names. I used the specific published action slugs instead, since the acceptance criterion asks each matcher to correspond to a real published action, and a bare vendor name would also match prose mentioning the vendor.

### Deduplication

Unchanged — `detectSecurityScanners` still collects into a `Set` and sorts. Added a case asserting a newly added scanner appearing in two workflows still yields one entry.

### Testing

Extended the existing `describe('detectSecurityScanners')` table test:

- one detection case per new matcher (15),
- three negative cases: the multi-armed-bandit line, an unscoped `rubocop --parallel` run, and a prose mention of sonarsource,
- one case asserting `rubocop --only Security/Eval` resolves to the `rubocop --only security` matcher,
- one dedup case.

```
npx vitest run          -> 13 files, 497 passed (was 477 on main)
npx eslint <both files> -> clean
```

Red-before-green: with the test file kept and `snapshot.ts` reverted, **17 of the new assertions fail**; with the change applied all 91 in the file pass. The three negative cases pass in both states by design — they guard against a future over-broad matcher rather than asserting the new behaviour.