### PR TITLE
Add a scale reference to the distribution charts

### DIFF
--- a/src/components/distribution-chart.tsx
+++ b/src/components/distribution-chart.tsx
@@ -19,6 +19,10 @@ const LABEL_WIDTH = 128;
 /** Wide enough for a four-digit commit count without clipping. */
 const VALUE_WIDTH = 52;
 const CHART_WIDTH = 520;
+/** Room under the plot for the max-value tick label. */
+const AXIS_HEIGHT = 16;
+/** Fractions of the maximum to draw a gridline at. */
+const GRID_FRACTIONS = [0.25, 0.5, 0.75, 1];
 
 export function DistributionChart({
   buckets,
@@ -38,7 +42,8 @@ export function DistributionChart({
 
   const max = Math.max(...buckets.map((bucket) => bucket.count), 1);
   const plotWidth = CHART_WIDTH - LABEL_WIDTH - VALUE_WIDTH;
-  const height = buckets.length * (BAR_HEIGHT + BAR_GAP);
+  const plotHeight = buckets.length * (BAR_HEIGHT + BAR_GAP);
+  const height = plotHeight + AXIS_HEIGHT;
   const summary = describeDistribution(buckets, noun);
 
   return (
@@ -63,6 +68,40 @@ export function DistributionChart({
           aria-label={summary}
           className="h-auto max-w-full"
         >
+          {/*
+            Scale reference, drawn first so the bars sit on top of it. Without
+            it a reader can compare bars to each other but has no sense of
+            whether the longest one is 12 or 1,200.
+
+            Only the maximum is labelled. Labelling every gridline would mean
+            inventing "nice" round numbers, and at a small maximum the quarter
+            marks are fractional counts — 0.5 of an issue is worse than no
+            label at all. One absolute anchor plus evenly spaced marks is
+            enough to read the scale off.
+          */}
+          <g aria-hidden="true">
+            {GRID_FRACTIONS.map((fraction) => (
+              <line
+                key={fraction}
+                x1={LABEL_WIDTH + fraction * plotWidth}
+                x2={LABEL_WIDTH + fraction * plotWidth}
+                y1={0}
+                y2={plotHeight}
+                strokeWidth={1}
+                className="stroke-border-subtle"
+              />
+            ))}
+
+            <text
+              x={LABEL_WIDTH + plotWidth}
+              y={plotHeight + AXIS_HEIGHT - 5}
+              textAnchor="end"
+              className="fill-muted text-[10px] tabular-nums"
+            >
+              {max}
+            </text>
+          </g>
+
           {buckets.map((bucket, index) => {
             const y = index * (BAR_HEIGHT + BAR_GAP);
             const width = bucket.count === 0 ? 0 : (bucket.count / max) * plotWidth;

--- a/tests/components/distribution-chart.test.tsx
+++ b/tests/components/distribution-chart.test.tsx
@@ -38,6 +38,89 @@ describe('DistributionChart', () => {
     expect(screen.getByRole('rowheader', { name: '0–7 days' })).toBeInTheDocument();
   });
 
+  it('draws a gridline at each quarter of the maximum', () => {
+    // A scale reference, so the reader can tell whether the longest bar is
+    // 12 or 1,200 without reading the value column.
+    const { container } = render(
+      <DistributionChart
+        buckets={bucketAges(AGES)}
+        title="Open issue age"
+        noun="open issues"
+      />,
+    );
+
+    const lines = [...container.querySelectorAll('line')];
+    expect(lines).toHaveLength(4);
+
+    // 128 label + 340 plot: quarters land at 213, 298, 383, 468.
+    expect(lines.map((line) => line.getAttribute('x1'))).toEqual([
+      '213',
+      '298',
+      '383',
+      '468',
+    ]);
+
+    // Vertical, and every line spans the full plot rather than one row.
+    for (const line of lines) {
+      expect(line.getAttribute('x1')).toBe(line.getAttribute('x2'));
+      expect(line.getAttribute('y1')).toBe('0');
+      expect(line.getAttribute('y2')).toBe('204');
+    }
+  });
+
+  it('labels the gridlines with the maximum count only', () => {
+    // Labelling every gridline would mean inventing round numbers, and at a
+    // small maximum the quarter marks are fractional counts.
+    const { container } = render(
+      <DistributionChart
+        buckets={bucketAges(AGES)}
+        title="Open issue age"
+        noun="open issues"
+      />,
+    );
+
+    const max = Math.max(...bucketAges(AGES).map((bucket) => bucket.count));
+    const tick = container.querySelector('g[aria-hidden="true"] text');
+
+    expect(tick).not.toBeNull();
+    expect(tick).toHaveTextContent(String(max));
+    expect(tick?.getAttribute('text-anchor')).toBe('end');
+  });
+
+  it('keeps the scale reference out of the accessibility tree', () => {
+    // The screen-reader table already carries exact values; gridlines would
+    // only be noise.
+    const { container } = render(
+      <DistributionChart
+        buckets={bucketAges(AGES)}
+        title="Open issue age"
+        noun="open issues"
+      />,
+    );
+
+    const grid = container.querySelector('g[aria-hidden="true"]');
+    expect(grid).not.toBeNull();
+    expect(grid?.querySelectorAll('line')).toHaveLength(4);
+  });
+
+  it('grows the viewBox for the axis without widening the chart', () => {
+    // The E2E suite asserts nothing overflows at 375px, so the scale
+    // reference must not cost horizontal room.
+    const { container } = render(
+      <DistributionChart
+        buckets={bucketAges(AGES)}
+        title="Open issue age"
+        noun="open issues"
+      />,
+    );
+
+    const svg = container.querySelector('svg');
+    // 6 buckets x 34 = 204 of plot, plus 16 of axis.
+    expect(svg?.getAttribute('viewBox')).toBe('0 0 520 220');
+    expect(svg?.getAttribute('width')).toBe('520');
+    expect(svg?.classList.contains('max-w-full')).toBe(true);
+  });
+
   it('renders nothing when there is too little data to chart', () => {
     // An empty frame would imply "we looked and found nothing to say".
     const { container } = render(


### PR DESCRIPTION
Closes #44.

The bars could be compared to each other but carried no sense of absolute scale — whether the longest one was 12 or 1,200 — without reading the value column.

### What it draws

- **Faint gridlines at 25/50/75/100% of the maximum**, rendered *before* the bars so the bars sit on top of them.
- **A single tick label** under the right edge of the plot, showing the maximum count.

### Design notes

**Why only the maximum is labelled.** Labelling every gridline would mean inventing "nice" round numbers, which is a real charting abstraction and explicitly out of scope. Worse, at a small maximum the quarter marks are fractional — a gridline labelled `0.5` of an issue is less useful than an unlabelled one. One absolute anchor plus evenly spaced marks is enough to read the scale off, and it keeps the change to what the issue asked for.

**Why `stroke-border-subtle`.** It resolves to `--border`, which is defined in `:root` (`#e2e8f0`) and again under `@media (prefers-color-scheme: dark)` (`#1f2b41`). So the gridlines are legible in both themes by construction rather than by a hand-picked colour, and they are literally the same weight as the app's own borders in `layout.tsx` and the report cards — visibly quieter than the `fill-accent` bars. This is a reference, not a feature.

**Why nothing overflows.** `CHART_WIDTH` is unchanged at 520. The gridlines are drawn inside the existing `plotWidth`, and the only growth is 16px of *vertical* room for the tick label, so the viewBox goes `0 0 520 220` from `0 0 520 204`. `width`, `max-w-full` and the `overflow-x-auto` wrapper are untouched, so the E2E 375px assertion is unaffected. There is a test pinning this.

**Accessibility.** The scale group is `aria-hidden`, and the screen-reader `<table>` is completely untouched — it already carries exact values, so gridlines would only be noise. Still zero client JavaScript: four `<line>` elements and a `<text>`, all server-rendered.

### Testing

Extended `tests/components/distribution-chart.test.tsx` with four cases:

- gridlines land at each quarter — asserts all four `x1` values (213/298/383/468), that each line is vertical, and that each spans the full plot height rather than one row;
- the tick is labelled with the maximum and right-anchored;
- the scale group is `aria-hidden` and the table is unaffected;
- the viewBox grows vertically only, with `width` still 520 and `max-w-full` still applied.

```
npx vitest run          -> 13 files, 481 passed (was 477 on main)
npx eslint <both files> -> clean
```

Red-before-green: with the test file kept and `distribution-chart.tsx` reverted, **all 4 new cases fail**; with the change applied all 9 in the file pass.

I could not run `npm run dev` to eyeball it, since that needs a provisioned Postgres for Prisma which I don't have here — so the light/dark legibility claim rests on the token argument above rather than on my having looked at it. Worth a glance when you pull it.