### PR TITLE
feat: add a manual refresh control to the analysis page

### DIFF
--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -1,7 +1,11 @@
 'use server';
 
+import { revalidatePath } from 'next/cache';
+import { headers } from 'next/headers';
 import { redirect } from 'next/navigation';
 
+import { getAnalysisService, refreshRateLimiter } from '@/lib/analysis/container';
+import { logger } from '@/lib/logging/logger';
 import { parseRepositoryReference } from '@/lib/validation/repository-reference';
 
 export interface SearchState {
@@ -35,4 +39,82 @@ export async function analyzeRepository(
   }
 
   redirect(`/r/${parsed.value.owner}/${parsed.value.name}`);
+}
+
+export interface RefreshState {
+  error?: string;
+}
+
+/**
+ * Identifies the caller for rate limiting.
+ *
+ * Only proxy-set headers are trusted, and only the first entry of
+ * `x-forwarded-for` — the rest are appended by intermediaries and are
+ * attacker-controlled. Behind no proxy at all every caller shares the
+ * `unknown` bucket, which is deliberately conservative: it under-serves a
+ * local developer rather than over-serving a real deployment.
+ */
+async function clientKey(): Promise<string> {
+  const headerList = await headers();
+  const forwarded = headerList.get('x-forwarded-for');
+  const first = forwarded?.split(',')[0]?.trim();
+
+  if (first !== undefined && first !== '') return first;
+  return headerList.get('x-real-ip') ?? 'unknown';
+}
+
+/** "45 seconds" / "2 minutes", so the message says when rather than how long. */
+function describeRetryAfter(seconds: number): string {
+  if (seconds < 60) {
+    return seconds === 1 ? '1 second' : `${seconds} seconds`;
+  }
+
+  const minutes = Math.ceil(seconds / 60);
+  return minutes === 1 ? '1 minute' : `${minutes} minutes`;
+}
+
+/**
+ * Re-runs an analysis, bypassing the cache.
+ *
+ * Every refresh spends GitHub rate limit, which is why `refreshRateLimiter` is
+ * capped far more tightly than ordinary analysis. Exceeding it returns a
+ * message naming when to try again rather than failing silently.
+ *
+ * The repository is read from the form rather than from the URL so the action
+ * validates its own input with the same parser as every other entry point,
+ * instead of trusting a value the caller supplies.
+ */
+export async function refreshAnalysis(
+  _previous: RefreshState,
+  formData: FormData,
+): Promise<RefreshState> {
+  const raw = formData.get('repository');
+  const input = typeof raw === 'string' ? raw : '';
+
+  const parsed = parseRepositoryReference(input);
+  if (!parsed.ok) return { error: parsed.error };
+
+  const limit = refreshRateLimiter.check(await clientKey());
+  if (!limit.allowed) {
+    return {
+      error: `Refresh limit reached. Try again in ${describeRetryAfter(limit.retryAfterSeconds)}.`,
+    };
+  }
+
+  const service = await getAnalysisService();
+
+  try {
+    await service.analyze(parsed.value, { forceRefresh: true });
+  } catch (error) {
+    // The page already renders analysis failures in full; here we only need to
+    // say the refresh did not happen, and leave the cached report on screen.
+    logger.warn('refresh_failed', {
+      repository: `${parsed.value.owner}/${parsed.value.name}`,
+      detail: error instanceof Error ? error.message : 'unknown',
+    });
+    return { error: 'Could not refresh right now. The report below is unchanged.' };
+  }
+
+  revalidatePath(`/r/${parsed.value.owner}/${parsed.value.name}`);
+  return {};
 }

--- a/src/app/r/[owner]/[repository]/page.tsx
+++ b/src/app/r/[owner]/[repository]/page.tsx
@@ -6,6 +6,7 @@ import { AnalysisError, PartialDataBanner } from '@/components/analysis-error';
 import { DistributionChart } from '@/components/distribution-chart';
 import { CategoryCard } from '@/components/category-card';
 import { FindingsList } from '@/components/findings';
+import { RefreshAnalysis } from '@/components/refresh-analysis';
 import { CategoryScoreBar, OverallScore } from '@/components/score-display';
 import { getAnalysisService } from '@/lib/analysis/container';
 import { currentSession, tokenProvider } from '@/lib/auth';
@@ -239,10 +240,18 @@ function AnalysisReport({
           <OverallScore score={overall.score} confidence={overall.confidence} />
         </div>
 
-        <p className="text-muted text-sm">
-          {cached ? <>Analyzed {formatAge(ageSeconds)}.</> : <>Analyzed just now.</>}{' '}
-          Scoring algorithm version {result.scoringVersion}.
-        </p>
+        {/*
+          The refresh control sits beside the age, not inside the paragraph: a
+          <form> is flow content and is not valid inside a <p>, which would end
+          the paragraph early in the parsed DOM.
+        */}
+        <div className="text-muted flex flex-wrap items-baseline gap-x-3 gap-y-1 text-sm">
+          <p>
+            {cached ? <>Analyzed {formatAge(ageSeconds)}.</> : <>Analyzed just now.</>}{' '}
+            Scoring algorithm version {result.scoringVersion}.
+          </p>
+          <RefreshAnalysis repository={repository.fullName} />
+        </div>
       </header>
 
       <PartialDataBanner limitations={limitations} />

--- a/src/components/refresh-analysis.tsx
+++ b/src/components/refresh-analysis.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import { useActionState } from 'react';
+
+import { refreshAnalysis, type RefreshState } from '@/app/actions';
+
+const INITIAL: RefreshState = {};
+
+/**
+ * The manual refresh control.
+ *
+ * A real `<form>` posting to a server action, like the search form, so it works
+ * before hydration and with JavaScript disabled — without JS the browser posts
+ * the form and the server re-renders the page, which is the whole interaction.
+ * `useActionState` only adds the pending state on top of that.
+ *
+ * The button is a plain `<button type="submit">` rather than anything
+ * custom, so it is keyboard operable for free and picks up the global
+ * `:focus-visible` ring in `globals.css`.
+ *
+ * The repository is submitted as a hidden field so the action can validate it
+ * with the same parser as every other entry point, rather than trusting the
+ * referring URL.
+ */
+export function RefreshAnalysis({ repository }: { repository: string }) {
+  const [state, formAction, pending] = useActionState(refreshAnalysis, INITIAL);
+  const errorId = 'refresh-error';
+
+  return (
+    <span className="inline-flex flex-wrap items-baseline gap-x-2 gap-y-1">
+      <form action={formAction} aria-busy={pending}>
+        <input type="hidden" name="repository" value={repository} />
+        <button
+          type="submit"
+          disabled={pending}
+          aria-describedby={state.error !== undefined ? errorId : undefined}
+          className="text-accent underline underline-offset-4 disabled:opacity-60"
+        >
+          {pending ? 'Refreshing…' : 'Refresh'}
+        </button>
+      </form>
+
+      {/*
+        Always rendered so the live region exists before it has content — a
+        region inserted at the same time as its text is not reliably announced.
+      */}
+      <span id={errorId} role="status" aria-live="polite" className="text-severity-high">
+        {pending ? 'Refreshing the analysis…' : (state.error ?? '')}
+      </span>
+    </span>
+  );
+}

--- a/src/lib/logging/logger.ts
+++ b/src/lib/logging/logger.ts
@@ -25,7 +25,8 @@ export type LogEvent =
   | 'sign_in_failed'
   | 'sign_out'
   | 'installation_token_failed'
-  | 'private_analysis';
+  | 'private_analysis'
+  | 'refresh_failed';
 
 /**
  * Named fields explicitly admit `undefined` rather than only being optional.

--- a/tests/components/refresh-analysis.test.tsx
+++ b/tests/components/refresh-analysis.test.tsx
@@ -1,0 +1,147 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { RefreshAnalysis } from '@/components/refresh-analysis';
+
+/**
+ * The server action is mocked rather than imported for real.
+ *
+ * `@/app/actions` pulls in the analysis container, which is `server-only` and
+ * throws by design when loaded outside a server environment. What is under test
+ * here is the control's states, not the action — the action's own behaviour is
+ * covered by the E2E refresh case.
+ */
+const { refreshAnalysis } = vi.hoisted(() => ({ refreshAnalysis: vi.fn() }));
+
+vi.mock('@/app/actions', () => ({ refreshAnalysis }));
+
+describe('RefreshAnalysis', () => {
+  beforeEach(() => {
+    refreshAnalysis.mockReset();
+  });
+
+  it('offers a submit button in a form that posts to the action', () => {
+    // A real form, so it still works before hydration and without JavaScript.
+    const { container } = render(<RefreshAnalysis repository="acme/toolkit" />);
+
+    const button = screen.getByRole('button', { name: 'Refresh' });
+    expect(button).toBeEnabled();
+    expect(button).toHaveAttribute('type', 'submit');
+    expect(container.querySelector('form')).not.toBeNull();
+  });
+
+  it('submits the repository so the action can validate it itself', () => {
+    // Rather than the action trusting the referring URL.
+    const { container } = render(<RefreshAnalysis repository="acme/toolkit" />);
+
+    const hidden = container.querySelector('input[type="hidden"]');
+    expect(hidden).toHaveAttribute('name', 'repository');
+    expect(hidden).toHaveValue('acme/toolkit');
+  });
+
+  it('exposes a live region before it has anything to say', () => {
+    // A region inserted at the same time as its text is not reliably announced.
+    render(<RefreshAnalysis repository="acme/toolkit" />);
+
+    const status = screen.getByRole('status');
+    expect(status).toBeInTheDocument();
+    expect(status).toHaveTextContent('');
+  });
+
+  it('reports its busy state while the refresh runs', async () => {
+    // Held open so the pending state is observable, then settled before the
+    // test ends — a promise left unresolved keeps React's action queue busy
+    // and the next test never leaves its pending state.
+    let settle: (state: { error?: string }) => void = () => {};
+    refreshAnalysis.mockImplementation(
+      () =>
+        new Promise<{ error?: string }>((resolve) => {
+          settle = resolve;
+        }),
+    );
+
+    const user = userEvent.setup();
+    const { container } = render(<RefreshAnalysis repository="acme/toolkit" />);
+
+    await user.click(screen.getByRole('button', { name: 'Refresh' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Refreshing…' })).toBeDisabled();
+    });
+    expect(container.querySelector('form')).toHaveAttribute('aria-busy', 'true');
+    expect(screen.getByRole('status')).toHaveTextContent('Refreshing the analysis…');
+
+    settle({});
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Refresh' })).toBeEnabled();
+    });
+    expect(container.querySelector('form')).toHaveAttribute('aria-busy', 'false');
+  });
+
+  it('explains when to try again once the refresh limit is reached', async () => {
+    // Exceeding the limit has to say when, not fail silently.
+    refreshAnalysis.mockResolvedValue({
+      error: 'Refresh limit reached. Try again in 3 minutes.',
+    });
+
+    const user = userEvent.setup();
+    render(<RefreshAnalysis repository="acme/toolkit" />);
+
+    await user.click(screen.getByRole('button', { name: 'Refresh' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('status')).toHaveTextContent(
+        'Refresh limit reached. Try again in 3 minutes.',
+      );
+    });
+  });
+
+  it('wires the message to the button so it is not just floating text', async () => {
+    refreshAnalysis.mockResolvedValue({ error: 'Refresh limit reached.' });
+
+    const user = userEvent.setup();
+    render(<RefreshAnalysis repository="acme/toolkit" />);
+
+    await user.click(screen.getByRole('button', { name: 'Refresh' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Refresh' })).toHaveAttribute(
+        'aria-describedby',
+        screen.getByRole('status').id,
+      );
+    });
+  });
+
+  it('returns to an idle, operable button after a successful refresh', async () => {
+    refreshAnalysis.mockResolvedValue({});
+
+    const user = userEvent.setup();
+    render(<RefreshAnalysis repository="acme/toolkit" />);
+
+    await user.click(screen.getByRole('button', { name: 'Refresh' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Refresh' })).toBeEnabled();
+    });
+    expect(screen.getByRole('status')).toHaveTextContent('');
+    expect(screen.getByRole('button', { name: 'Refresh' })).not.toHaveAttribute(
+      'aria-describedby',
+    );
+  });
+
+  it('is reachable and operable from the keyboard alone', async () => {
+    // A native submit button, so this is free — the test guards against it
+    // being replaced with something that is not.
+    refreshAnalysis.mockResolvedValue({});
+
+    const user = userEvent.setup();
+    render(<RefreshAnalysis repository="acme/toolkit" />);
+
+    await user.tab();
+    expect(screen.getByRole('button', { name: 'Refresh' })).toHaveFocus();
+
+    await user.keyboard('{Enter}');
+    await waitFor(() => expect(refreshAnalysis).toHaveBeenCalledTimes(1));
+  });
+});

--- a/tests/e2e/analysis.spec.ts
+++ b/tests/e2e/analysis.spec.ts
@@ -239,6 +239,54 @@ test.describe('responsive layout', () => {
   });
 });
 
+/**
+ * The refresh path.
+ *
+ * Deliberately a single test rather than several. `refreshRateLimiter` is
+ * per-server-process and allows 5 refreshes per 5 minutes, so two tests that
+ * both refresh would share that budget and whichever ran second could be
+ * limited — flaky in exactly the way the rest of this suite avoids. One test
+ * owns the budget and walks it from success to limit.
+ */
+test.describe('manual refresh', () => {
+  test('refreshes on demand, then explains when to try again', async ({ page }) => {
+    await page.goto('/r/acme/toolkit');
+
+    const refresh = page.getByRole('button', { name: 'Refresh' });
+    const status = page.getByRole('status');
+
+    // Sits beside the freshness line rather than somewhere else on the page.
+    await expect(page.getByText(/analyzed/i).first()).toBeVisible();
+    await expect(refresh).toBeVisible();
+
+    // Keyboard operable with a visible focus state.
+    await refresh.focus();
+    await expect(refresh).toBeFocused();
+    await page.keyboard.press('Enter');
+
+    // The report stays on screen and the control returns to idle.
+    await expect(refresh).toBeEnabled();
+    await expect(page.getByRole('heading', { name: 'acme/toolkit' })).toBeVisible();
+    await expect(page.getByText(/scoring algorithm version/i)).toBeVisible();
+
+    // The limiter allows 5 per window; keep going until it says stop. The
+    // bound is the limit plus a couple of attempts, so a regression that
+    // never limits fails here rather than looping.
+    for (let attempt = 0; attempt < 7; attempt += 1) {
+      if ((await status.textContent())?.includes('Refresh limit reached') === true) break;
+      await refresh.click();
+      await expect(refresh).toBeEnabled();
+    }
+
+    // Named a time to try again rather than failing silently.
+    await expect(status).toContainText(/refresh limit reached/i);
+    await expect(status).toContainText(/try again in \d+ (second|minute)s?/i);
+
+    // And the report is still there — a refused refresh does not blank it.
+    await expect(page.getByRole('heading', { name: 'acme/toolkit' })).toBeVisible();
+  });
+});
+
 test.describe('security headers', () => {
   test('sets a nonce-based CSP and the standard hardening headers', async ({ page }) => {
     const response = await page.goto('/');


### PR DESCRIPTION
Closes #45.

`AnalysisService` supported `forceRefresh` and `refreshRateLimiter` was configured, but nothing exposed either.

### What was added

- **`refreshAnalysis`** in `src/app/actions.ts` — validates, rate limits, calls `service.analyze(ref, { forceRefresh: true })`, then `revalidatePath`.
- **`RefreshAnalysis`** in `src/components/refresh-analysis.tsx` — a form posting to that action.
- Wired in beside the freshness line on the analysis page.
- `refresh_failed` added to `LogEvent`.

### Design notes

**It is a real form, not a fetch.** Same shape as `RepositorySearch`: a `<form action={formAction}>` with `useActionState` layered on top only for the pending state. So it works before hydration and with JavaScript disabled — the browser posts the form and the server re-renders, which is the entire interaction.

**The button is a native `<button type="submit">`.** That makes it keyboard operable for free, and it inherits the global `:focus-visible` ring already defined in `globals.css` rather than carrying a bespoke focus style. There is a test asserting tab-then-Enter submits, so a future replacement with a non-native control fails rather than silently regressing.

**The repository is a hidden field, re-parsed server-side.** The action runs `parseRepositoryReference` on it, the same parser as the search form and the route segments, rather than trusting the referring URL. It validates its own input.

**Client key for rate limiting.** Only the *first* `x-forwarded-for` entry is trusted — the rest are appended by intermediaries and are attacker-controlled — falling back to `x-real-ip`, then `unknown`. Behind no proxy every caller shares the `unknown` bucket. That is deliberate and commented: it under-serves a local developer rather than over-serving a real deployment.

**Placement.** The control sits *beside* the freshness paragraph, in a shared flex row, not inside it. A `<form>` is flow content and is not valid inside a `<p>`, so nesting it would close the paragraph early in the parsed DOM.

**A failed refresh leaves the report alone.** It logs `refresh_failed` and returns a message saying the report below is unchanged, rather than replacing a good cached analysis with an error.

### Testing

**Component tests** — `tests/components/refresh-analysis.test.tsx`, 8 cases covering the control's states: idle, the hidden field, the live region existing before it has content, the busy state (`aria-busy`, disabled, status text), the rate-limit message, `aria-describedby` wiring, return to idle, and keyboard operation. The action is mocked, since `@/app/actions` pulls in the `server-only` container by design.

**E2E** — one case in `tests/e2e/analysis.spec.ts`, deliberately a single test: `refreshRateLimiter` is per-process and allows 5 per 5 minutes, so two refreshing tests would share that budget and whichever ran second could be limited. One test owns the budget and walks it from success through to the limit.

**Ran locally:**

```
npm run format:check  -> clean
npm run lint          -> clean
npm run typecheck     -> clean
npm test              -> 14 files, 485 passed (was 477 on main)
npm run build         -> compiled successfully
```

**Verified in a running dev server** (`GITHUB_FIXTURES=1`, no `DATABASE_URL`, so the in-memory store), against `/r/acme/toolkit`:

- Clicking Refresh logs `analysis_started` with **no preceding `cache_hit`** — confirming `forceRefresh` genuinely bypassed the cache — then `analysis_completed`, then `cache_hit ageSeconds:0` as the page re-renders from `revalidatePath`.
- After the 6th refresh the status region read exactly: **"Refresh limit reached. Try again in 4 minutes."**
- At that point the button was back to enabled with `aria-describedby="refresh-error"`, and the report — heading, freshness line, scores — was still on screen.

**Not run locally:** Playwright. I don't have the browsers installed here and disk was too tight to download them, so the E2E case above is written but unexecuted — CI is its first real run. Flagging that explicitly rather than implying it passed.

I also noticed my two earlier PRs (#48, #49) used branch names without the issue number, contrary to the `type/issue-number-short-description` convention in CONTRIBUTING. This one follows it; happy to redo the others if it matters for your tooling.