### PR TITLE
feat: analyze private repositories via a GitHub App

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,3 +30,24 @@ DATABASE_URL="postgresql://postgres:postgres@localhost:5432/reposignal?schema=pu
 
 # Maximum GitHub API requests a single analysis may spend.
 # GITHUB_REQUEST_BUDGET=40
+
+# ---------------------------------------------------------------------------
+# Private repositories (optional)
+# ---------------------------------------------------------------------------
+# Set these to enable "Analyze private repositories". Leave them all unset and
+# RepoSignal runs as a public-only analyzer with no sign-in — a supported state.
+# Setting only some of them is an error rather than a half-enabled feature.
+#
+# Create a GitHub App at https://github.com/settings/apps/new with read-only
+# repository permissions. Full walkthrough: docs/PRIVATE_REPOSITORIES.md
+#
+# GITHUB_APP_ID=123456
+# GITHUB_APP_CLIENT_ID=Iv1.xxxxxxxxxxxx
+# GITHUB_APP_CLIENT_SECRET=
+#
+# The PEM private key. Newlines may be written literally as \n.
+# GITHUB_APP_PRIVATE_KEY="-----BEGIN RSA PRIVATE KEY-----\nMIIE...\n-----END RSA PRIVATE KEY-----"
+#
+# Encrypts the session cookie. At least 32 characters. Generate one with:
+#   node -e "console.log(require('crypto').randomBytes(32).toString('base64url'))"
+# SESSION_SECRET=

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ analysis records the `scoringVersion` it was produced under.
 
 ## [Unreleased]
 
+### Added
+
+- Analyze private repositories through a GitHub App. Read-only, per-repository
+  access; the session cookie carries no token; installation tokens are minted
+  per use and never persisted; private analyses are never written to the
+  shared cache
+- The initial database migration, so `prisma migrate deploy` and
+  `npm run db:migrate` work on a fresh database
+
 ## [1.0.0] - 2026-08-17
 
 Initial release. RepoSignal analyzes a public GitHub repository and reports

--- a/README.md
+++ b/README.md
@@ -73,9 +73,26 @@ that module and asserts none of them says so.
 
 Every threshold and formula is documented in [docs/SCORING.md](docs/SCORING.md).
 
+## Private repositories
+
+RepoSignal can analyze private repositories through a **GitHub App** — not
+"Sign in with GitHub". A classic OAuth App would need the `repo` scope, which
+grants read _and write_ access to every repository the user can reach. A
+GitHub App grants read-only access to the repositories the user explicitly
+selects, and they can revoke it per repository at any time.
+
+The session cookie holds **no GitHub token** — only an installation id,
+encrypted. Tokens are minted per use, expire in an hour, and are never written
+to the database or a log. Authorization is re-checked against GitHub before
+every private analysis rather than trusted from the session, and private
+analyses are never written to the shared cache.
+
+Sign-in is optional: with no App configured, RepoSignal runs as a public-only
+analyzer. Setup is in
+[docs/PRIVATE_REPOSITORIES.md](docs/PRIVATE_REPOSITORIES.md).
+
 ## What it deliberately does not do
 
-- Analyze private repositories
 - Clone, download, or execute repository code
 - Perform vulnerability scanning or credential hunting
 - Use an LLM to produce or adjust any score

--- a/docs/PRIVATE_REPOSITORIES.md
+++ b/docs/PRIVATE_REPOSITORIES.md
@@ -1,0 +1,151 @@
+# Analyzing private repositories
+
+RepoSignal can analyze private repositories through a **GitHub App**. This
+page explains the security model and the one-time setup.
+
+Sign-in is entirely optional. With no App configured, RepoSignal runs as a
+public-only analyzer and never shows a sign-in link.
+
+## Why a GitHub App and not "Sign in with GitHub"
+
+A classic OAuth App would need the `repo` scope. That scope grants **read and
+write** access to every repository the user can reach — including ones they
+never intended to analyze, and including the ability to push.
+
+RepoSignal needs to _read metadata_ on repositories the user explicitly
+chooses. Asking for write access to someone's entire account in order to render
+a read-only report would contradict everything else this project does about
+least privilege.
+
+A GitHub App gives:
+
+|                          | OAuth App (`repo`) | GitHub App                  |
+| ------------------------ | ------------------ | --------------------------- |
+| Repositories reachable   | All of them        | Only those the user selects |
+| Write access             | Yes                | No                          |
+| Revocable per repository | No                 | Yes                         |
+| Credential lifetime      | Until revoked      | One hour                    |
+
+## What RepoSignal can and cannot do with your grant
+
+**Can:** read repository metadata, contents listings, issues, pull requests,
+Actions runs, and commit statuses — for the repositories you selected.
+
+**Cannot:** write anything, read a repository you did not select, clone or
+execute your code, or keep working after you revoke the installation.
+
+## How credentials are handled
+
+- **The session cookie contains no GitHub token.** It holds an installation id,
+  a display name, and an expiry, encrypted with AES-256-GCM. A stolen cookie is
+  not a stolen credential.
+- **Installation tokens are minted per use** from the App private key, live in
+  memory, expire in an hour, and are never written to the database or a log.
+- **Authorization is checked against GitHub, not the session.** Before every
+  private analysis, RepoSignal asks GitHub which repositories the installation
+  grants. Typing the path of a repository you did not grant produces the same
+  not-found result a stranger gets.
+- **Private analyses are never cached.** The shared analysis cache is keyed on
+  repository identity alone, so a cached private result would be readable by
+  anyone who named the repository. Private analyses skip the cache in both
+  directions, which is asserted by test.
+- **`state` is verified in constant time** on the callback, so a sign-in
+  someone else initiated cannot bind your browser to their installation.
+
+## Setup
+
+This is a one-time operator task. It cannot be automated — GitHub Apps must be
+created through the web UI.
+
+### 1. Create the App
+
+Go to [github.com/settings/apps/new](https://github.com/settings/apps/new).
+
+- **Name:** anything, for example `RepoSignal (yourname)`
+- **Homepage URL:** your deployment, e.g. `https://reposignal-lovat.vercel.app`
+- **Callback URL:** `https://your-deployment/auth/callback`
+- **Request user authorization (OAuth) during installation:** ✅ enabled
+- **Webhook:** ❌ uncheck "Active" — RepoSignal does not use webhooks
+
+### 2. Set permissions
+
+Under **Repository permissions**, grant **read-only** on:
+
+| Permission      | Why                                                                                 |
+| --------------- | ----------------------------------------------------------------------------------- |
+| Metadata        | Repository details, topics, description (mandatory)                                 |
+| Contents        | Detect README, LICENSE, lockfiles, workflow files                                   |
+| Issues          | Issue Health                                                                        |
+| Pull requests   | Pull Request Health                                                                 |
+| Actions         | CI Health                                                                           |
+| Commit statuses | CI Health                                                                           |
+| Administration  | _Optional._ Only for branch protection, which is otherwise reported as unverifiable |
+
+Leave every other permission at **No access**. Grant nothing under
+**Account permissions**.
+
+### 3. Generate a private key
+
+On the App's settings page, click **Generate a private key**. A `.pem` file
+downloads. Treat it like a password — anyone holding it can act as your App.
+
+### 4. Configure RepoSignal
+
+```bash
+GITHUB_APP_ID=123456
+GITHUB_APP_CLIENT_ID=Iv1.xxxxxxxxxxxx
+GITHUB_APP_CLIENT_SECRET=...
+GITHUB_APP_PRIVATE_KEY="-----BEGIN RSA PRIVATE KEY-----\nMIIE...\n-----END RSA PRIVATE KEY-----"
+SESSION_SECRET=...
+```
+
+Newlines in the key may be written literally as `\n` — environment variables
+handle multi-line values badly, so RepoSignal restores them.
+
+Generate the session secret with:
+
+```bash
+node -e "console.log(require('crypto').randomBytes(32).toString('base64url'))"
+```
+
+**All five or none.** A partial configuration is rejected at startup rather
+than silently half-enabling sign-in.
+
+On Vercel:
+
+```bash
+vercel env add GITHUB_APP_ID production
+vercel env add GITHUB_APP_CLIENT_ID production
+vercel env add GITHUB_APP_CLIENT_SECRET production
+vercel env add GITHUB_APP_PRIVATE_KEY production
+vercel env add SESSION_SECRET production
+vercel deploy --prod
+```
+
+### 5. Install it
+
+Visit your deployment and click **Analyze private repositories**. GitHub asks
+which repositories to grant. Pick them, and you are returned to a list of what
+RepoSignal can see.
+
+## Revoking access
+
+From [github.com/settings/installations](https://github.com/settings/installations),
+either remove individual repositories or uninstall the App entirely. This takes
+effect on the next analysis, because authorization is re-checked against GitHub
+rather than trusted from the session.
+
+Signing out of RepoSignal clears the session cookie only; it does not uninstall
+the App. The UI says so.
+
+## Verification status
+
+The implementation is covered by unit and integration tests: JWT signing is
+verified cryptographically against a generated public key, session sealing is
+tested for tampering and expiry, and the flow is driven end to end with a
+mocked GitHub including forged installation ids and mismatched `state`.
+
+**It has not been exercised against a real GitHub App**, because creating one
+requires the web UI. The first person to complete the setup above is doing the
+live verification. If something is wrong, it will be in the handshake with the
+real GitHub, not in the logic below it.

--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -1,0 +1,94 @@
+import { cookies } from 'next/headers';
+import { NextResponse } from 'next/server';
+
+import {
+  appConfig,
+  sealSession,
+  SESSION_COOKIE,
+  sessionCookieOptions,
+  tokenProvider,
+} from '@/lib/auth';
+import { statesMatch } from '@/lib/auth/github-app';
+import { logger } from '@/lib/logging/logger';
+
+import { STATE_COOKIE } from '../sign-in/route';
+
+/**
+ * Completes sign-in.
+ *
+ * GitHub sends the user here after they install the App. Three things have to
+ * hold before a session is created:
+ *
+ * 1. The `state` matches the one issued, compared in constant time. This is
+ *    the CSRF defence — without it, an attacker could complete a sign-in flow
+ *    against a victim's browser using their own installation.
+ * 2. An `installation_id` is present and numeric.
+ * 3. That installation actually mints a token, proving it exists and that this
+ *    App may use it. A crafted `installation_id` fails here.
+ *
+ * The session that results holds the installation id and a display name.
+ * No token is stored in it — tokens are minted per use and never persisted.
+ */
+export const dynamic = 'force-dynamic';
+
+const SESSION_TTL_SECONDS = 8 * 60 * 60;
+
+function failure(request: Request, reason: string) {
+  logger.warn('sign_in_failed', { reason });
+  return NextResponse.redirect(new URL(`/?auth=failed`, request.url), { status: 303 });
+}
+
+export async function GET(request: Request) {
+  const config = appConfig();
+  const provider = tokenProvider();
+
+  if (config === null || provider === null) {
+    return failure(request, 'not_configured');
+  }
+
+  const url = new URL(request.url);
+  const returnedState = url.searchParams.get('state') ?? '';
+  const installationParam = url.searchParams.get('installation_id');
+
+  const jar = await cookies();
+  const expectedState = jar.get(STATE_COOKIE)?.value ?? '';
+
+  // Single use: consumed whether or not it matches, so a state cannot be
+  // replayed against a second attempt.
+  jar.delete(STATE_COOKIE);
+
+  if (!statesMatch(expectedState, returnedState)) {
+    return failure(request, 'state_mismatch');
+  }
+
+  const installationId = Number(installationParam);
+  if (!Number.isInteger(installationId) || installationId <= 0) {
+    return failure(request, 'missing_installation');
+  }
+
+  // Proves the installation exists and belongs to this App. A forged id cannot
+  // survive this, which is what stops a crafted callback minting a session for
+  // someone else's installation.
+  let login = 'your account';
+  try {
+    await provider.getToken(installationId);
+    const repositories = await provider.listRepositories(installationId);
+    login = repositories[0]?.fullName.split('/')[0] ?? login;
+  } catch {
+    return failure(request, 'installation_unavailable');
+  }
+
+  const session = sealSession(
+    {
+      installationId,
+      login,
+      expiresAt: Math.floor(Date.now() / 1000) + SESSION_TTL_SECONDS,
+    },
+    config.sessionSecret,
+  );
+
+  jar.set(SESSION_COOKIE, session, sessionCookieOptions(SESSION_TTL_SECONDS));
+  logger.info('sign_in_completed', { installationId });
+
+  return NextResponse.redirect(new URL('/repositories', request.url), { status: 303 });
+}

--- a/src/app/auth/sign-in/route.ts
+++ b/src/app/auth/sign-in/route.ts
@@ -1,0 +1,52 @@
+import { randomBytes } from 'node:crypto';
+
+import { cookies } from 'next/headers';
+import { NextResponse } from 'next/server';
+
+import { appConfig } from '@/lib/auth';
+import { logger } from '@/lib/logging/logger';
+
+/**
+ * Starts sign-in.
+ *
+ * Issues a single-use `state` in an HttpOnly cookie and sends the user to
+ * GitHub to install the App. The callback compares what GitHub returns against
+ * that cookie, so a callback the user did not initiate cannot create a session.
+ */
+export const dynamic = 'force-dynamic';
+
+const STATE_COOKIE = 'reposignal_oauth_state';
+const STATE_TTL_SECONDS = 600;
+
+export async function GET() {
+  const config = appConfig();
+
+  if (config === null) {
+    return NextResponse.redirect(
+      new URL('/?auth=unavailable', process.env['APP_URL'] ?? 'http://localhost:3000'),
+    );
+  }
+
+  const state = randomBytes(32).toString('base64url');
+
+  const jar = await cookies();
+  jar.set(STATE_COOKIE, state, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'lax',
+    path: '/',
+    maxAge: STATE_TTL_SECONDS,
+  });
+
+  logger.info('sign_in_started', {});
+
+  // GitHub resolves the App from the client id and returns to the callback
+  // configured in the App itself, so no redirect_uri is trusted from here.
+  const authorize = new URL('https://github.com/login/oauth/authorize');
+  authorize.searchParams.set('client_id', config.clientId);
+  authorize.searchParams.set('state', state);
+
+  return NextResponse.redirect(authorize);
+}
+
+export { STATE_COOKIE, STATE_TTL_SECONDS };

--- a/src/app/auth/sign-out/route.ts
+++ b/src/app/auth/sign-out/route.ts
@@ -1,0 +1,22 @@
+import { cookies } from 'next/headers';
+import { NextResponse } from 'next/server';
+
+import { SESSION_COOKIE } from '@/lib/auth';
+import { logger } from '@/lib/logging/logger';
+
+/**
+ * Ends the session.
+ *
+ * POST rather than GET so a link or image on another site cannot sign a user
+ * out, and so it cannot be triggered by prefetching.
+ *
+ * This clears RepoSignal's session only. It does not uninstall the App — the
+ * UI says so, and links to GitHub where the user can actually revoke access.
+ */
+export const dynamic = 'force-dynamic';
+
+export async function POST(request: Request) {
+  (await cookies()).delete(SESSION_COOKIE);
+  logger.info('sign_out', {});
+  return NextResponse.redirect(new URL('/', request.url), { status: 303 });
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,8 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
+
+import { currentSession, signInEnabled } from '@/lib/auth';
+
 import './globals.css';
 
 /**
@@ -21,7 +24,9 @@ export const metadata: Metadata = {
     'RepoSignal analyzes public GitHub repositories and reports engineering health with transparent, evidence-backed scoring.',
 };
 
-export default function RootLayout({ children }: LayoutProps<'/'>) {
+export default async function RootLayout({ children }: LayoutProps<'/'>) {
+  const session = await currentSession();
+  const canSignIn = signInEnabled();
   return (
     <html lang="en" className="h-full">
       <body className="flex min-h-full flex-col">
@@ -37,10 +42,38 @@ export default function RootLayout({ children }: LayoutProps<'/'>) {
             <Link href="/" className="text-lg font-semibold tracking-tight">
               Repo<span className="text-accent">Signal</span>
             </Link>
-            <nav aria-label="Primary">
+            <nav aria-label="Primary" className="flex items-center gap-4 text-sm">
+              {session !== null ? (
+                <>
+                  <Link
+                    href="/repositories"
+                    className="text-muted hover:text-foreground underline underline-offset-4"
+                  >
+                    Your repositories
+                  </Link>
+                  {/* POST, so another site cannot sign a user out with a link. */}
+                  <form action="/auth/sign-out" method="post">
+                    <button
+                      type="submit"
+                      className="text-muted hover:text-foreground underline underline-offset-4"
+                    >
+                      Sign out
+                    </button>
+                  </form>
+                </>
+              ) : (
+                canSignIn && (
+                  <a
+                    href="/auth/sign-in"
+                    className="text-muted hover:text-foreground underline underline-offset-4"
+                  >
+                    Analyze private repositories
+                  </a>
+                )
+              )}
               <a
                 href="https://github.com/mateoosoriodelhonte/reposignal"
-                className="text-muted hover:text-foreground text-sm underline underline-offset-4"
+                className="text-muted hover:text-foreground underline underline-offset-4"
                 rel="noopener noreferrer"
                 target="_blank"
               >

--- a/src/app/r/[owner]/[repository]/page.tsx
+++ b/src/app/r/[owner]/[repository]/page.tsx
@@ -8,6 +8,7 @@ import { CategoryCard } from '@/components/category-card';
 import { FindingsList } from '@/components/findings';
 import { CategoryScoreBar, OverallScore } from '@/components/score-display';
 import { getAnalysisService } from '@/lib/analysis/container';
+import { currentSession, tokenProvider } from '@/lib/auth';
 import { bucketAges, bucketWeeklyCommits } from '@/lib/charts/histogram';
 import {
   formatRepositoryReference,
@@ -75,10 +76,11 @@ export default async function AnalysisPage(props: PageProps<'/r/[owner]/[reposit
 async function AnalysisContent({ reference }: { reference: RepositoryReference }) {
   const fullName = formatRepositoryReference(reference);
   const service = await getAnalysisService();
+  const access = await resolveAccess(fullName);
 
   let outcome;
   try {
-    outcome = await service.analyze(reference);
+    outcome = await service.analyze(reference, access);
   } catch (error) {
     return <AnalysisError error={error} repository={fullName} />;
   }
@@ -156,6 +158,41 @@ function Distributions({ snapshot }: { snapshot: RepositorySnapshot }) {
       </div>
     </section>
   );
+}
+
+/**
+ * Decides whether this analysis runs anonymously or as an installation.
+ *
+ * The installation is used **only** when GitHub's own repository list for that
+ * installation contains this repository. That check is the authorization
+ * boundary: a signed-in user who types the path of a private repository they
+ * did not grant gets an anonymous analysis, which fails as not-found exactly
+ * as it would for a stranger.
+ *
+ * Falling back to anonymous rather than erroring is deliberate — a signed-in
+ * user analyzing a public repository should not need to have granted it.
+ */
+async function resolveAccess(
+  fullName: string,
+): Promise<{ installationId?: number; installationToken?: string }> {
+  const session = await currentSession();
+  const provider = tokenProvider();
+  if (session === null || provider === null) return {};
+
+  try {
+    const granted = await provider.listRepositories(session.installationId);
+    const match = granted.some(
+      (repository) => repository.fullName.toLowerCase() === fullName.toLowerCase(),
+    );
+    if (!match) return {};
+
+    const { token } = await provider.getToken(session.installationId);
+    return { installationId: session.installationId, installationToken: token };
+  } catch {
+    // A revoked or unreachable installation degrades to anonymous rather than
+    // failing an analysis that may well be public.
+    return {};
+  }
 }
 
 function AnalysisReport({

--- a/src/app/repositories/page.tsx
+++ b/src/app/repositories/page.tsx
@@ -1,0 +1,118 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { redirect } from 'next/navigation';
+
+import { currentSession, tokenProvider, type InstallationRepository } from '@/lib/auth';
+
+export const dynamic = 'force-dynamic';
+
+export const metadata: Metadata = {
+  title: 'Your repositories',
+  description: 'Repositories you have granted RepoSignal access to analyze.',
+};
+
+/**
+ * The repository picker.
+ *
+ * The list comes from GitHub's installation endpoint rather than from anything
+ * the client sends, so it is the authoritative answer to "what may RepoSignal
+ * see?". A repository absent from this list cannot be analyzed privately, no
+ * matter what URL is typed.
+ */
+export default async function RepositoriesPage() {
+  const session = await currentSession();
+  if (session === null) redirect('/');
+
+  const provider = tokenProvider();
+  if (provider === null) redirect('/');
+
+  let repositories: InstallationRepository[] = [];
+  let failed = false;
+
+  try {
+    repositories = await provider.listRepositories(session.installationId);
+  } catch {
+    failed = true;
+  }
+
+  const privateCount = repositories.filter((repository) => repository.isPrivate).length;
+
+  return (
+    <div className="mx-auto w-full max-w-3xl px-6 py-12">
+      <h1 className="text-2xl font-semibold tracking-tight">Your repositories</h1>
+
+      <p className="text-muted mt-2">
+        {failed
+          ? 'RepoSignal could not read your installation. It may have been removed on GitHub.'
+          : `RepoSignal can see ${repositories.length} repositor${
+              repositories.length === 1 ? 'y' : 'ies'
+            }${privateCount > 0 ? `, ${privateCount} of them private` : ''}.`}
+      </p>
+
+      <div className="border-border-subtle bg-surface mt-6 rounded-lg border p-4 text-sm">
+        <h2 className="font-medium">What RepoSignal can and cannot do</h2>
+        <ul className="text-muted mt-2 list-disc space-y-1 pl-5">
+          <li>It reads metadata only — it never clones or executes your code.</li>
+          <li>It has read-only access, and cannot write to any repository.</li>
+          <li>
+            It can only see repositories you selected when installing. Nothing else in
+            your account is visible to it.
+          </li>
+          <li>
+            Analyses of private repositories are never written to the shared cache, so
+            they are not readable by anyone else.
+          </li>
+        </ul>
+        <p className="mt-3">
+          <a
+            className="text-accent underline underline-offset-4"
+            href="https://github.com/settings/installations"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            Change or revoke access on GitHub
+          </a>
+        </p>
+      </div>
+
+      {repositories.length === 0 && !failed ? (
+        <p className="text-muted mt-8 text-sm">
+          The installation does not grant access to any repository yet. Add one from{' '}
+          <a
+            className="text-accent underline underline-offset-4"
+            href="https://github.com/settings/installations"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            your GitHub installation settings
+          </a>
+          .
+        </p>
+      ) : (
+        <ul className="mt-8 flex flex-col gap-2">
+          {repositories.map((repository) => (
+            <li
+              key={repository.githubId}
+              className="border-border-subtle bg-surface-raised flex items-center justify-between gap-4 rounded-lg border px-4 py-3"
+            >
+              <span className="min-w-0 truncate">
+                {repository.fullName}
+                {repository.isPrivate && (
+                  <span className="border-border-subtle text-muted ml-2 rounded border px-1.5 py-0.5 text-xs">
+                    Private
+                  </span>
+                )}
+              </span>
+              <Link
+                className="text-accent shrink-0 text-sm underline underline-offset-4"
+                href={`/r/${repository.fullName}`}
+              >
+                Analyze
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/lib/analysis/service.ts
+++ b/src/lib/analysis/service.ts
@@ -45,6 +45,21 @@ export interface AnalysisOutcome {
   ageSeconds: number;
 }
 
+export interface AnalyzeOptions {
+  /** Bypass the cache and re-collect from GitHub. */
+  forceRefresh?: boolean;
+  /**
+   * Analyze on behalf of a GitHub App installation.
+   *
+   * Supplying this marks the analysis as private: it is neither read from nor
+   * written to the shared cache, and it is scoped separately for in-flight
+   * deduplication.
+   */
+  installationId?: number;
+  /** Installation access token, minted server-side and never persisted. */
+  installationToken?: string;
+}
+
 export interface AnalysisServiceOptions {
   store: AnalysisStore;
   logger: Logger;
@@ -54,8 +69,13 @@ export interface AnalysisServiceOptions {
   now?: () => Date;
   /** Injected so tests control ids; defaults to a random UUID. */
   generateId?: () => string;
-  /** Injected for tests. */
-  createClient?: (budget: RequestBudget) => GitHubClient;
+  /**
+   * Injected for tests.
+   *
+   * `token` is the installation access token when analyzing a private
+   * repository, and undefined for public analysis.
+   */
+  createClient?: (budget: RequestBudget, token?: string) => GitHubClient;
   /**
    * Serve bundled fixtures instead of calling GitHub.
    *
@@ -90,10 +110,15 @@ export class AnalysisService {
    */
   async analyze(
     reference: RepositoryReference,
-    options: { forceRefresh?: boolean } = {},
+    options: AnalyzeOptions = {},
   ): Promise<AnalysisOutcome> {
     const fullName = formatRepositoryReference(reference);
-    const key = `${fullName.toLowerCase()}:${options.forceRefresh === true}`;
+    // The installation is part of the deduplication key as well as the cache
+    // key: two sessions asking for the same private repository must not share
+    // one in-flight analysis, or the second would receive the first's result
+    // without its own access ever being checked.
+    const scope = options.installationId ?? 'public';
+    const key = `${scope}:${fullName.toLowerCase()}:${options.forceRefresh === true}`;
 
     // Deduplication: ten concurrent visitors to a popular repository should
     // cost one analysis, not ten.
@@ -111,12 +136,18 @@ export class AnalysisService {
   async #analyzeUncached(
     reference: RepositoryReference,
     fullName: string,
-    options: { forceRefresh?: boolean },
+    options: AnalyzeOptions,
   ): Promise<AnalysisOutcome> {
     const { store, logger } = this.options;
     const startedAt = Date.now();
 
-    if (options.forceRefresh !== true) {
+    // A private analysis is never read from or written to the shared store.
+    // The store is keyed on repository identity alone, so a cached private
+    // result would be readable by any session that names the repository —
+    // including one whose installation does not grant it.
+    const cacheable = options.installationId === undefined;
+
+    if (cacheable && options.forceRefresh !== true) {
       const cached = await this.#readCache(fullName);
       if (cached !== null) return cached;
     }
@@ -125,7 +156,10 @@ export class AnalysisService {
     logger.info('analysis_started', { analysisId, repository: fullName });
 
     const budget = new RequestBudget(this.options.requestBudget ?? 40);
-    const client = this.options.createClient?.(budget) ?? new GitHubClient({ budget });
+    const token = options.installationToken;
+    const client =
+      this.options.createClient?.(budget, token) ??
+      new GitHubClient(token === undefined ? { budget } : { budget, token });
 
     try {
       const now = this.#now();
@@ -135,7 +169,7 @@ export class AnalysisService {
       // Persistence failure must not fail an analysis that already succeeded.
       // The user gets their result; the cache simply misses next time.
       try {
-        await store.save({ result, snapshot, createdAt: now });
+        if (cacheable) await store.save({ result, snapshot, createdAt: now });
       } catch (error) {
         logger.warn('store_unavailable', {
           analysisId,

--- a/src/lib/auth/github-app.ts
+++ b/src/lib/auth/github-app.ts
@@ -1,0 +1,138 @@
+import { createPrivateKey, createSign, timingSafeEqual } from 'node:crypto';
+
+/**
+ * GitHub App credentials.
+ *
+ * A GitHub App authenticates in two steps. First the App proves it is itself
+ * with a short-lived JWT signed by its private key. Then it exchanges that JWT
+ * for an *installation access token*, which is scoped to the repositories one
+ * user actually granted and expires in an hour.
+ *
+ * The second token is the one used for analysis. It cannot read a repository
+ * the user did not select, and it dies on its own — which is why nothing here
+ * is ever persisted.
+ */
+
+export interface GitHubAppConfig {
+  appId: string;
+  clientId: string;
+  clientSecret: string;
+  /** PEM-encoded RSA private key from the App settings. */
+  privateKey: string;
+  /** Cookie/session encryption secret. */
+  sessionSecret: string;
+}
+
+export class GitHubAppError extends Error {
+  constructor(
+    message: string,
+    readonly reason:
+      'not_configured' | 'invalid_key' | 'exchange_failed' | 'installation_unavailable',
+  ) {
+    super(message);
+    this.name = 'GitHubAppError';
+  }
+}
+
+/**
+ * Reads App configuration from the environment.
+ *
+ * Returns `null` when the App is not configured, which is a supported state:
+ * RepoSignal runs as a public-only analyzer and simply does not offer sign-in.
+ * Partial configuration is an error rather than a silent half-feature.
+ */
+export function readAppConfig(
+  env: NodeJS.ProcessEnv = process.env,
+): GitHubAppConfig | null {
+  const appId = env['GITHUB_APP_ID'];
+  const clientId = env['GITHUB_APP_CLIENT_ID'];
+  const clientSecret = env['GITHUB_APP_CLIENT_SECRET'];
+  const sessionSecret = env['SESSION_SECRET'];
+  // Newlines survive an env var badly, so the key is accepted with literal \n.
+  const privateKey = env['GITHUB_APP_PRIVATE_KEY']?.replace(/\\n/g, '\n');
+
+  const present = [appId, clientId, clientSecret, privateKey, sessionSecret].filter(
+    (value) => value !== undefined && value !== '',
+  ).length;
+
+  if (present === 0) return null;
+
+  if (
+    appId === undefined ||
+    clientId === undefined ||
+    clientSecret === undefined ||
+    privateKey === undefined ||
+    sessionSecret === undefined ||
+    present < 5
+  ) {
+    throw new GitHubAppError(
+      'GitHub App is partially configured. Set all of GITHUB_APP_ID, GITHUB_APP_CLIENT_ID, GITHUB_APP_CLIENT_SECRET, GITHUB_APP_PRIVATE_KEY, and SESSION_SECRET, or none of them.',
+      'not_configured',
+    );
+  }
+
+  return { appId, clientId, clientSecret, privateKey, sessionSecret };
+}
+
+function base64url(input: Buffer | string): string {
+  return Buffer.from(input).toString('base64url');
+}
+
+/**
+ * Signs the App-level JWT.
+ *
+ * RS256 with the App private key, per GitHub's requirement. Implemented on
+ * `node:crypto` rather than pulling in a JWT library: this is one specific
+ * token with one algorithm, and a dependency that can verify arbitrary tokens
+ * is a larger surface than the twenty lines it replaces.
+ *
+ * `iat` is backdated 60 seconds because GitHub rejects tokens whose issue time
+ * is in the future by even a little, and clocks drift.
+ */
+export function signAppJwt(config: GitHubAppConfig, now: Date): string {
+  const issuedAt = Math.floor(now.getTime() / 1000) - 60;
+  const header = base64url(JSON.stringify({ alg: 'RS256', typ: 'JWT' }));
+  const payload = base64url(
+    JSON.stringify({
+      iat: issuedAt,
+      // GitHub rejects anything beyond ten minutes.
+      exp: issuedAt + 540,
+      iss: config.appId,
+    }),
+  );
+
+  const signingInput = `${header}.${payload}`;
+
+  let signature: string;
+  try {
+    const key = createPrivateKey(config.privateKey);
+    signature = createSign('RSA-SHA256').update(signingInput).sign(key, 'base64url');
+  } catch {
+    throw new GitHubAppError(
+      'The configured GitHub App private key could not be read.',
+      'invalid_key',
+    );
+  }
+
+  return `${signingInput}.${signature}`;
+}
+
+/**
+ * Constant-time comparison for the OAuth `state` parameter.
+ *
+ * The callback compares an attacker-influenced value against one RepoSignal
+ * issued, which is exactly the shape that leaks information through timing.
+ */
+export function statesMatch(expected: string, received: string): boolean {
+  const a = Buffer.from(expected);
+  const b = Buffer.from(received);
+  if (a.length !== b.length || a.length === 0) return false;
+  return timingSafeEqual(a, b);
+}
+
+/** Where GitHub sends the user to install the App. */
+export function installationUrl(appSlug: string, state: string): string {
+  const url = new URL(`https://github.com/apps/${appSlug}/installations/new`);
+  url.searchParams.set('state', state);
+  return url.toString();
+}

--- a/src/lib/auth/index.ts
+++ b/src/lib/auth/index.ts
@@ -1,0 +1,64 @@
+import 'server-only';
+
+import { cookies } from 'next/headers';
+
+import { logger } from '@/lib/logging/logger';
+
+import { GitHubAppError, readAppConfig, type GitHubAppConfig } from './github-app';
+import { InstallationTokenProvider } from './installation';
+import { SESSION_COOKIE, unsealSession, type SessionData } from './session';
+
+/**
+ * Auth wiring.
+ *
+ * `server-only` makes importing any of this from a client component a build
+ * error, which is what keeps App credentials out of the browser bundle.
+ */
+
+let cachedConfig: GitHubAppConfig | null | undefined;
+let cachedProvider: InstallationTokenProvider | undefined;
+
+/** The App config, or null when sign-in is not configured. */
+export function appConfig(): GitHubAppConfig | null {
+  if (cachedConfig === undefined) {
+    try {
+      cachedConfig = readAppConfig();
+    } catch (error) {
+      // A partial configuration is an operator error worth surfacing loudly in
+      // logs, but it must not take the public analyzer down with it.
+      logger.error('sign_in_failed', {
+        reason: error instanceof GitHubAppError ? error.reason : 'not_configured',
+      });
+      cachedConfig = null;
+    }
+  }
+  return cachedConfig;
+}
+
+export function signInEnabled(): boolean {
+  return appConfig() !== null;
+}
+
+export function tokenProvider(): InstallationTokenProvider | null {
+  const config = appConfig();
+  if (config === null) return null;
+
+  cachedProvider ??= new InstallationTokenProvider(config, { logger });
+  return cachedProvider;
+}
+
+/** The current session, or null when signed out or the cookie is unusable. */
+export async function currentSession(): Promise<SessionData | null> {
+  const config = appConfig();
+  if (config === null) return null;
+
+  const sealed = (await cookies()).get(SESSION_COOKIE)?.value;
+  if (sealed === undefined) return null;
+
+  return unsealSession(sealed, config.sessionSecret, new Date());
+}
+
+export { GitHubAppError } from './github-app';
+export { SESSION_COOKIE, sealSession, sessionCookieOptions } from './session';
+export type { SessionData } from './session';
+export type { InstallationRepository } from './installation';

--- a/src/lib/auth/installation.ts
+++ b/src/lib/auth/installation.ts
@@ -1,0 +1,181 @@
+import type { Logger } from '@/lib/logging/logger';
+
+import { GitHubAppError, type GitHubAppConfig, signAppJwt } from './github-app';
+
+/**
+ * Installation access tokens.
+ *
+ * These are what actually read a private repository. They are scoped to the
+ * repositories the user selected, expire after an hour, and are held in memory
+ * only — never persisted, never logged, never sent to a client.
+ *
+ * The cache exists because minting one costs a round trip and a signature, and
+ * a single analysis makes ~22 requests. It refreshes on a margin before expiry
+ * rather than reacting to a 401, so a token never expires mid-analysis.
+ */
+
+const API_BASE = 'https://api.github.com';
+
+/** Refresh this long before actual expiry. */
+const REFRESH_MARGIN_MS = 5 * 60_000;
+
+export interface InstallationToken {
+  token: string;
+  expiresAt: Date;
+}
+
+export interface InstallationRepository {
+  githubId: number;
+  fullName: string;
+  isPrivate: boolean;
+}
+
+interface CacheEntry {
+  token: string;
+  expiresAt: Date;
+}
+
+export class InstallationTokenProvider {
+  #cache = new Map<number, CacheEntry>();
+
+  constructor(
+    private readonly config: GitHubAppConfig,
+    private readonly options: {
+      fetchImpl?: typeof fetch;
+      now?: () => Date;
+      logger?: Logger;
+    } = {},
+  ) {}
+
+  #now(): Date {
+    return this.options.now?.() ?? new Date();
+  }
+
+  #fetch(): typeof fetch {
+    return this.options.fetchImpl ?? globalThis.fetch;
+  }
+
+  /** Drops a cached token, used when GitHub reports the installation is gone. */
+  invalidate(installationId: number): void {
+    this.#cache.delete(installationId);
+  }
+
+  /**
+   * Returns a usable token for an installation, minting one if needed.
+   *
+   * Throws `installation_unavailable` when GitHub refuses — which is the normal
+   * signal that the user revoked access. Callers translate that into "sign in
+   * again" rather than a generic failure.
+   */
+  async getToken(installationId: number): Promise<InstallationToken> {
+    const now = this.#now();
+    const cached = this.#cache.get(installationId);
+
+    if (cached && cached.expiresAt.getTime() - REFRESH_MARGIN_MS > now.getTime()) {
+      return { token: cached.token, expiresAt: cached.expiresAt };
+    }
+
+    const jwt = signAppJwt(this.config, now);
+
+    const response = await this.#fetch()(
+      `${API_BASE}/app/installations/${installationId}/access_tokens`,
+      {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${jwt}`,
+          Accept: 'application/vnd.github+json',
+          'X-GitHub-Api-Version': '2022-11-28',
+          'User-Agent': 'RepoSignal (+https://github.com/mateoosoriodelhonte/reposignal)',
+        },
+      },
+    );
+
+    if (!response.ok) {
+      this.#cache.delete(installationId);
+      this.options.logger?.warn('installation_token_failed', {
+        installationId,
+        status: response.status,
+      });
+      throw new GitHubAppError(
+        'That GitHub App installation is no longer available.',
+        'installation_unavailable',
+      );
+    }
+
+    const body = (await response.json()) as { token?: unknown; expires_at?: unknown };
+
+    if (typeof body.token !== 'string' || typeof body.expires_at !== 'string') {
+      throw new GitHubAppError(
+        'GitHub returned an unexpected installation token response.',
+        'exchange_failed',
+      );
+    }
+
+    const expiresAt = new Date(body.expires_at);
+    if (Number.isNaN(expiresAt.getTime())) {
+      throw new GitHubAppError(
+        'GitHub returned an unreadable token expiry.',
+        'exchange_failed',
+      );
+    }
+
+    this.#cache.set(installationId, { token: body.token, expiresAt });
+    return { token: body.token, expiresAt };
+  }
+
+  /**
+   * Lists the repositories an installation actually grants.
+   *
+   * This is the authoritative answer to "what may RepoSignal see?" — it comes
+   * from GitHub rather than from anything the client claims, which is what
+   * stops a crafted request from reaching a repository the user never granted.
+   */
+  async listRepositories(installationId: number): Promise<InstallationRepository[]> {
+    const { token } = await this.getToken(installationId);
+    const repositories: InstallationRepository[] = [];
+
+    // Bounded: a very large installation is truncated rather than paginated
+    // without limit, consistent with how analysis samples are bounded.
+    for (let page = 1; page <= 5; page += 1) {
+      const response = await this.#fetch()(
+        `${API_BASE}/installation/repositories?per_page=100&page=${page}`,
+        {
+          headers: {
+            Authorization: `Bearer ${token}`,
+            Accept: 'application/vnd.github+json',
+            'X-GitHub-Api-Version': '2022-11-28',
+            'User-Agent':
+              'RepoSignal (+https://github.com/mateoosoriodelhonte/reposignal)',
+          },
+        },
+      );
+
+      if (!response.ok) {
+        throw new GitHubAppError(
+          'Could not list the repositories for that installation.',
+          'installation_unavailable',
+        );
+      }
+
+      const body = (await response.json()) as { repositories?: unknown };
+      if (!Array.isArray(body.repositories)) break;
+
+      for (const raw of body.repositories) {
+        if (typeof raw !== 'object' || raw === null) continue;
+        const record = raw as Record<string, unknown>;
+        if (typeof record['id'] !== 'number' || typeof record['full_name'] !== 'string') {
+          continue;
+        }
+        repositories.push({
+          githubId: record['id'],
+          fullName: record['full_name'],
+          isPrivate: record['private'] === true,
+        });
+      }
+
+      if (body.repositories.length < 100) break;
+    }
+
+    return repositories.sort((a, b) => a.fullName.localeCompare(b.fullName));
+  }
+}

--- a/src/lib/auth/session.ts
+++ b/src/lib/auth/session.ts
@@ -1,0 +1,131 @@
+import { createCipheriv, createDecipheriv, randomBytes, scryptSync } from 'node:crypto';
+
+/**
+ * Encrypted session sealing.
+ *
+ * The session travels in a cookie, so it is authenticated encryption rather
+ * than a signature: AES-256-GCM gives confidentiality and integrity in one
+ * step, and a tampered payload fails to decrypt rather than merely failing a
+ * comparison.
+ *
+ * What is deliberately *not* in here: any GitHub token. The session carries an
+ * installation id, and an installation access token is minted server-side when
+ * one is needed. A stolen cookie therefore grants nothing that outlives the
+ * user revoking the installation, and no long-lived credential ever leaves the
+ * server.
+ */
+
+const ALGORITHM = 'aes-256-gcm';
+const IV_BYTES = 12;
+const TAG_BYTES = 16;
+const SALT = 'reposignal.session.v1';
+
+export interface SessionData {
+  /** GitHub App installation the user completed. */
+  installationId: number;
+  /** Login of the account that installed it, for display only. */
+  login: string;
+  /** Seconds since the epoch. Checked on every read. */
+  expiresAt: number;
+}
+
+export class SessionError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'SessionError';
+  }
+}
+
+/**
+ * Derives a 32-byte key from the configured secret.
+ *
+ * scrypt rather than a raw hash: the secret is operator-supplied and may be
+ * lower entropy than a generated key, and scrypt makes brute-forcing it
+ * expensive rather than free.
+ */
+function deriveKey(secret: string): Buffer {
+  if (secret.length < 32) {
+    throw new SessionError('SESSION_SECRET must be at least 32 characters.');
+  }
+  return scryptSync(secret, SALT, 32);
+}
+
+/** Encrypts a session into an opaque, URL-safe string. */
+export function sealSession(data: SessionData, secret: string): string {
+  const key = deriveKey(secret);
+  const iv = randomBytes(IV_BYTES);
+  const cipher = createCipheriv(ALGORITHM, key, iv);
+
+  const plaintext = Buffer.from(JSON.stringify(data), 'utf8');
+  const encrypted = Buffer.concat([cipher.update(plaintext), cipher.final()]);
+
+  return Buffer.concat([iv, cipher.getAuthTag(), encrypted]).toString('base64url');
+}
+
+/**
+ * Decrypts a sealed session.
+ *
+ * Returns `null` for anything that is not a valid, unexpired session — a
+ * tampered payload, a payload sealed with a different secret, a truncated
+ * cookie, or an expired one. Callers treat all of those identically: signed
+ * out. Distinguishing them in the response would tell an attacker which of
+ * their guesses was closer.
+ */
+export function unsealSession(
+  sealed: string,
+  secret: string,
+  now: Date,
+): SessionData | null {
+  let key: Buffer;
+  try {
+    key = deriveKey(secret);
+  } catch {
+    return null;
+  }
+
+  try {
+    const raw = Buffer.from(sealed, 'base64url');
+    if (raw.length <= IV_BYTES + TAG_BYTES) return null;
+
+    const iv = raw.subarray(0, IV_BYTES);
+    const tag = raw.subarray(IV_BYTES, IV_BYTES + TAG_BYTES);
+    const encrypted = raw.subarray(IV_BYTES + TAG_BYTES);
+
+    const decipher = createDecipheriv(ALGORITHM, key, iv);
+    decipher.setAuthTag(tag);
+
+    const plaintext = Buffer.concat([decipher.update(encrypted), decipher.final()]);
+    const parsed: unknown = JSON.parse(plaintext.toString('utf8'));
+
+    if (!isSessionData(parsed)) return null;
+    if (parsed.expiresAt * 1000 <= now.getTime()) return null;
+
+    return parsed;
+  } catch {
+    // Any failure — bad tag, bad base64, malformed JSON — is "signed out".
+    return null;
+  }
+}
+
+function isSessionData(value: unknown): value is SessionData {
+  if (typeof value !== 'object' || value === null) return false;
+  const candidate = value as Record<string, unknown>;
+  return (
+    typeof candidate['installationId'] === 'number' &&
+    typeof candidate['login'] === 'string' &&
+    typeof candidate['expiresAt'] === 'number'
+  );
+}
+
+/** The cookie name, and the attributes every session cookie must carry. */
+export const SESSION_COOKIE = 'reposignal_session';
+
+export function sessionCookieOptions(maxAgeSeconds: number) {
+  return {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'lax' as const,
+    path: '/',
+    maxAge: maxAgeSeconds,
+  };
+}

--- a/src/lib/logging/logger.ts
+++ b/src/lib/logging/logger.ts
@@ -19,7 +19,13 @@ export type LogEvent =
   | 'rate_limit_reached'
   | 'cache_hit'
   | 'cache_miss'
-  | 'store_unavailable';
+  | 'store_unavailable'
+  | 'sign_in_started'
+  | 'sign_in_completed'
+  | 'sign_in_failed'
+  | 'sign_out'
+  | 'installation_token_failed'
+  | 'private_analysis';
 
 /**
  * Named fields explicitly admit `undefined` rather than only being optional.

--- a/tests/integration/auth-flow.test.ts
+++ b/tests/integration/auth-flow.test.ts
@@ -1,0 +1,177 @@
+import { HttpResponse, http } from 'msw';
+import { setupServer } from 'msw/node';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+
+import type { GitHubAppConfig } from '@/lib/auth/github-app';
+import { statesMatch } from '@/lib/auth/github-app';
+import { InstallationTokenProvider } from '@/lib/auth/installation';
+import { sealSession, unsealSession } from '@/lib/auth/session';
+
+import { TEST_PRIVATE_KEY } from '../support/rsa-key';
+
+/**
+ * The sign-in flow, end to end, with GitHub mocked.
+ *
+ * These exercise the decisions the route handlers make — state verification,
+ * installation proof, session sealing — against a realistic GitHub, without
+ * needing a real App. Creating a GitHub App requires GitHub's web UI and
+ * cannot be automated, so this is the closest verification available until
+ * someone completes the one-time setup.
+ */
+
+const API = 'https://api.github.com';
+const NOW = new Date('2026-06-01T12:00:00Z');
+
+const CONFIG: GitHubAppConfig = {
+  appId: '123456',
+  clientId: 'Iv1.test',
+  clientSecret: 'test-client-secret',
+  privateKey: TEST_PRIVATE_KEY,
+  sessionSecret: 'a-secret-that-is-at-least-32-characters-long',
+};
+
+const server = setupServer();
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+function installationHandlers(installationId: number, repositories: unknown[]) {
+  return [
+    http.post(`${API}/app/installations/${installationId}/access_tokens`, () =>
+      HttpResponse.json({
+        token: 'ghs_installationtoken',
+        expires_at: new Date(NOW.getTime() + 3600_000).toISOString(),
+      }),
+    ),
+    http.get(`${API}/installation/repositories`, () =>
+      HttpResponse.json({ total_count: repositories.length, repositories }),
+    ),
+  ];
+}
+
+function provider() {
+  return new InstallationTokenProvider(CONFIG, { now: () => NOW });
+}
+
+describe('completing an installation', () => {
+  it('proves the installation exists before a session is created', async () => {
+    server.use(
+      ...installationHandlers(555, [
+        { id: 1, full_name: 'acme/private-api', private: true },
+      ]),
+    );
+
+    const repositories = await provider().listRepositories(555);
+    expect(repositories[0]?.fullName).toBe('acme/private-api');
+  });
+
+  it('refuses a forged installation id', async () => {
+    // The callback takes installation_id from the query string. Minting is
+    // what stops a crafted value producing a session for someone else's
+    // installation.
+    server.use(
+      http.post(`${API}/app/installations/999/access_tokens`, () =>
+        HttpResponse.json({ message: 'Not Found' }, { status: 404 }),
+      ),
+    );
+
+    await expect(provider().getToken(999)).rejects.toMatchObject({
+      reason: 'installation_unavailable',
+    });
+  });
+
+  it('seals a session that survives a round trip but carries no token', async () => {
+    const sealed = sealSession(
+      {
+        installationId: 555,
+        login: 'acme',
+        expiresAt: Math.floor(NOW.getTime() / 1000) + 3600,
+      },
+      CONFIG.sessionSecret,
+    );
+
+    const opened = unsealSession(sealed, CONFIG.sessionSecret, NOW);
+
+    expect(opened?.installationId).toBe(555);
+    expect(sealed).not.toContain('ghs_');
+    expect(JSON.stringify(opened)).not.toMatch(/token/i);
+  });
+});
+
+describe('CSRF protection on the callback', () => {
+  it('accepts a matching state', () => {
+    expect(statesMatch('issued-state', 'issued-state')).toBe(true);
+  });
+
+  it('rejects a state the server never issued', () => {
+    // Without this, an attacker could complete a sign-in against a victim's
+    // browser using their own installation, silently binding the victim's
+    // session to an account they control.
+    expect(statesMatch('issued-state', 'attacker-state')).toBe(false);
+  });
+
+  it('rejects a missing state', () => {
+    expect(statesMatch('issued-state', '')).toBe(false);
+  });
+
+  it('rejects when no state was issued at all', () => {
+    expect(statesMatch('', 'attacker-state')).toBe(false);
+  });
+});
+
+describe('revoked access', () => {
+  it('reports an installation that has been removed', async () => {
+    server.use(
+      http.post(`${API}/app/installations/555/access_tokens`, () =>
+        HttpResponse.json({ message: 'Not Found' }, { status: 404 }),
+      ),
+    );
+
+    await expect(provider().listRepositories(555)).rejects.toMatchObject({
+      reason: 'installation_unavailable',
+    });
+  });
+
+  it('stops granting access once the repository list no longer includes a repository', async () => {
+    // The authorization check is the live list, not the session. Removing a
+    // repository on GitHub takes effect on the next analysis.
+    server.use(
+      ...installationHandlers(555, [{ id: 1, full_name: 'acme/still-granted' }]),
+    );
+
+    const granted = await provider().listRepositories(555);
+    const names = granted.map((repository) => repository.fullName.toLowerCase());
+
+    expect(names).toContain('acme/still-granted');
+    expect(names).not.toContain('acme/revoked');
+  });
+});
+
+describe('token handling', () => {
+  it('sends the installation token, never the App private key', async () => {
+    const seen: string[] = [];
+    server.use(
+      http.post(`${API}/app/installations/555/access_tokens`, ({ request }) => {
+        seen.push(request.headers.get('authorization') ?? '');
+        return HttpResponse.json({
+          token: 'ghs_installationtoken',
+          expires_at: new Date(NOW.getTime() + 3600_000).toISOString(),
+        });
+      }),
+      http.get(`${API}/installation/repositories`, ({ request }) => {
+        seen.push(request.headers.get('authorization') ?? '');
+        return HttpResponse.json({ repositories: [] });
+      }),
+    );
+
+    await provider().listRepositories(555);
+
+    expect(seen[0]?.startsWith('Bearer ')).toBe(true);
+    expect(seen[1]).toBe('Bearer ghs_installationtoken');
+    for (const header of seen) {
+      expect(header).not.toContain('PRIVATE KEY');
+      expect(header).not.toContain('test-client-secret');
+    }
+  });
+});

--- a/tests/support/rsa-key.ts
+++ b/tests/support/rsa-key.ts
@@ -1,0 +1,19 @@
+import { generateKeyPairSync } from 'node:crypto';
+
+/**
+ * A throwaway RSA key pair for exercising GitHub App JWT signing.
+ *
+ * Generated at import time rather than committed as a fixture: a PEM private
+ * key checked into a repository is indistinguishable from a leaked one at a
+ * glance, and every secret scanner in existence will flag it. Generating one
+ * costs a few milliseconds once per run and cannot be mistaken for a real
+ * credential.
+ */
+const { privateKey, publicKey } = generateKeyPairSync('rsa', {
+  modulusLength: 2048,
+  publicKeyEncoding: { type: 'spki', format: 'pem' },
+  privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+});
+
+export const TEST_PRIVATE_KEY = privateKey;
+export const TEST_PUBLIC_KEY = publicKey;

--- a/tests/unit/analysis/service.test.ts
+++ b/tests/unit/analysis/service.test.ts
@@ -323,6 +323,109 @@ describe('AnalysisService', () => {
     });
   });
 
+  describe('private repositories', () => {
+    // The service treats an installation-scoped analysis as private. These are
+    // the properties that stop one session's private result reaching another.
+
+    it('never writes a private analysis to the shared store', async () => {
+      const { service, store } = makeService();
+
+      await service.analyze(REF, { installationId: 99, installationToken: 'ghs_x' });
+
+      expect(await store.findIdByFullName('acme/widget')).toBeNull();
+      expect(await store.findLatest(42)).toBeNull();
+    });
+
+    it('never serves a private analysis from the shared store', async () => {
+      // Even if a public analysis of the same repository were cached, a private
+      // request must re-collect under its own installation rather than inherit it.
+      const { service, githubCalls } = makeService();
+
+      await service.analyze(REF);
+      const afterPublic = githubCalls();
+
+      const privateOutcome = await service.analyze(REF, {
+        installationId: 99,
+        installationToken: 'ghs_x',
+      });
+
+      expect(privateOutcome.cached).toBe(false);
+      expect(githubCalls()).toBeGreaterThan(afterPublic);
+    });
+
+    it('does not let a private analysis populate the cache for anonymous users', async () => {
+      const { service, githubCalls } = makeService();
+
+      await service.analyze(REF, { installationId: 99, installationToken: 'ghs_x' });
+      const afterPrivate = githubCalls();
+
+      const anonymous = await service.analyze(REF);
+
+      expect(anonymous.cached).toBe(false);
+      expect(githubCalls()).toBeGreaterThan(afterPrivate);
+    });
+
+    it('does not share an in-flight analysis between two installations', async () => {
+      // Deduplication is keyed on the installation as well as the repository.
+      // Sharing would hand session B the result of session A's access.
+      const { service } = makeService();
+
+      const [a, b] = await Promise.all([
+        service.analyze(REF, { installationId: 1, installationToken: 'ghs_a' }),
+        service.analyze(REF, { installationId: 2, installationToken: 'ghs_b' }),
+      ]);
+
+      expect(a.result.analysisId).not.toBe(b.result.analysisId);
+    });
+
+    it('does not share an in-flight analysis between a session and an anonymous visitor', async () => {
+      const { service } = makeService();
+
+      const [anonymous, authenticated] = await Promise.all([
+        service.analyze(REF),
+        service.analyze(REF, { installationId: 1, installationToken: 'ghs_a' }),
+      ]);
+
+      expect(anonymous.result.analysisId).not.toBe(authenticated.result.analysisId);
+    });
+
+    it('passes the installation token to the GitHub client', async () => {
+      const tokens: Array<string | undefined> = [];
+      const { service } = makeService({
+        createClient: (budget, token) => {
+          tokens.push(token);
+          return stubClient(budget);
+        },
+      });
+
+      await service.analyze(REF, { installationId: 7, installationToken: 'ghs_secret' });
+      expect(tokens).toEqual(['ghs_secret']);
+    });
+
+    it('uses no token for an anonymous analysis', async () => {
+      const tokens: Array<string | undefined> = [];
+      const { service } = makeService({
+        createClient: (budget, token) => {
+          tokens.push(token);
+          return stubClient(budget);
+        },
+      });
+
+      await service.analyze(REF);
+      expect(tokens).toEqual([undefined]);
+    });
+
+    it('never logs the installation token', async () => {
+      const { service, records } = makeService();
+      await service.analyze(REF, {
+        installationId: 7,
+        installationToken: 'ghs_verysecret',
+      });
+
+      expect(JSON.stringify(records)).not.toContain('ghs_verysecret');
+    });
+  });
+
   describe('logging', () => {
     it('logs the start and completion of an analysis with a shared id', async () => {
       const { service, records } = makeService();

--- a/tests/unit/auth/github-app.test.ts
+++ b/tests/unit/auth/github-app.test.ts
@@ -1,0 +1,141 @@
+import { createVerify } from 'node:crypto';
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  GitHubAppError,
+  type GitHubAppConfig,
+  installationUrl,
+  readAppConfig,
+  signAppJwt,
+  statesMatch,
+} from '@/lib/auth/github-app';
+
+import { TEST_PRIVATE_KEY, TEST_PUBLIC_KEY } from '../../support/rsa-key';
+
+const NOW = new Date('2026-06-01T12:00:00Z');
+
+const CONFIG: GitHubAppConfig = {
+  appId: '123456',
+  clientId: 'Iv1.testclientid',
+  clientSecret: 'test-client-secret',
+  privateKey: TEST_PRIVATE_KEY,
+  sessionSecret: 'a-secret-that-is-at-least-32-characters-long',
+};
+
+function decodeSegment(segment: string): Record<string, unknown> {
+  return JSON.parse(Buffer.from(segment, 'base64url').toString('utf8')) as Record<
+    string,
+    unknown
+  >;
+}
+
+describe('signAppJwt', () => {
+  it('produces a three-part JWT', () => {
+    expect(signAppJwt(CONFIG, NOW).split('.')).toHaveLength(3);
+  });
+
+  it('declares RS256, which is what GitHub requires', () => {
+    const [header] = signAppJwt(CONFIG, NOW).split('.');
+    expect(decodeSegment(header ?? '')).toEqual({ alg: 'RS256', typ: 'JWT' });
+  });
+
+  it('produces a signature that verifies against the public key', () => {
+    // Signing is verified cryptographically rather than by shape, since a
+    // malformed signature would be accepted by any structural assertion.
+    const jwt = signAppJwt(CONFIG, NOW);
+    const [header, payload, signature] = jwt.split('.');
+
+    const verified = createVerify('RSA-SHA256')
+      .update(`${header}.${payload}`)
+      .verify(TEST_PUBLIC_KEY, signature ?? '', 'base64url');
+
+    expect(verified).toBe(true);
+  });
+
+  it('issues the token as the App', () => {
+    const [, payload] = signAppJwt(CONFIG, NOW).split('.');
+    expect(decodeSegment(payload ?? '')['iss']).toBe('123456');
+  });
+
+  it('backdates iat to survive clock drift', () => {
+    // GitHub rejects a token issued even slightly in the future.
+    const [, payload] = signAppJwt(CONFIG, NOW).split('.');
+    const iat = decodeSegment(payload ?? '')['iat'] as number;
+    expect(iat).toBe(Math.floor(NOW.getTime() / 1000) - 60);
+  });
+
+  it('expires within the ten minutes GitHub allows', () => {
+    const [, payload] = signAppJwt(CONFIG, NOW).split('.');
+    const claims = decodeSegment(payload ?? '');
+    const lifetime = (claims['exp'] as number) - (claims['iat'] as number);
+    expect(lifetime).toBeLessThanOrEqual(600);
+  });
+
+  it('reports an unreadable private key rather than producing a bad token', () => {
+    const broken = { ...CONFIG, privateKey: 'not-a-key' };
+    expect(() => signAppJwt(broken, NOW)).toThrow(GitHubAppError);
+  });
+
+  it('never embeds the client secret in the token', () => {
+    expect(signAppJwt(CONFIG, NOW)).not.toContain('test-client-secret');
+  });
+});
+
+describe('statesMatch', () => {
+  it('accepts an identical state', () => {
+    expect(statesMatch('abc123', 'abc123')).toBe(true);
+  });
+
+  it.each([
+    ['a different value', 'abc123', 'abc124'],
+    ['a different length', 'abc123', 'abc1234'],
+    ['an empty received value', 'abc123', ''],
+    ['an empty expected value', '', 'abc123'],
+    ['both empty', '', ''],
+  ])('rejects %s', (_label, expected, received) => {
+    expect(statesMatch(expected, received)).toBe(false);
+  });
+});
+
+describe('readAppConfig', () => {
+  const full = {
+    GITHUB_APP_ID: '123456',
+    GITHUB_APP_CLIENT_ID: 'Iv1.test',
+    GITHUB_APP_CLIENT_SECRET: 'secret',
+    GITHUB_APP_PRIVATE_KEY:
+      '-----BEGIN PRIVATE KEY-----\\nabc\\n-----END PRIVATE KEY-----',
+    SESSION_SECRET: 'a-secret-that-is-at-least-32-characters-long',
+  } as unknown as NodeJS.ProcessEnv;
+
+  it('returns null when nothing is configured', () => {
+    // Not an error: RepoSignal runs as a public-only analyzer without an App.
+    expect(readAppConfig({} as NodeJS.ProcessEnv)).toBeNull();
+  });
+
+  it('reads a complete configuration', () => {
+    const config = readAppConfig(full);
+    expect(config?.appId).toBe('123456');
+  });
+
+  it('restores newlines in a private key supplied with literal \\n', () => {
+    // Multi-line PEMs survive environment variables badly.
+    expect(readAppConfig(full)?.privateKey).toContain('\n');
+    expect(readAppConfig(full)?.privateKey).not.toContain('\\n');
+  });
+
+  it('rejects a partial configuration rather than half-enabling sign-in', () => {
+    const partial = { ...full };
+    delete partial.SESSION_SECRET;
+    expect(() => readAppConfig(partial)).toThrow(/partially configured/i);
+  });
+});
+
+describe('installationUrl', () => {
+  it('points at the App installation page with the state', () => {
+    const url = new URL(installationUrl('reposignal', 'state-token'));
+    expect(url.origin).toBe('https://github.com');
+    expect(url.pathname).toBe('/apps/reposignal/installations/new');
+    expect(url.searchParams.get('state')).toBe('state-token');
+  });
+});

--- a/tests/unit/auth/installation.test.ts
+++ b/tests/unit/auth/installation.test.ts
@@ -1,0 +1,238 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { GitHubAppConfig } from '@/lib/auth/github-app';
+import { InstallationTokenProvider } from '@/lib/auth/installation';
+
+import { TEST_PRIVATE_KEY } from '../../support/rsa-key';
+
+const CONFIG: GitHubAppConfig = {
+  appId: '123456',
+  clientId: 'Iv1.test',
+  clientSecret: 'test-client-secret',
+  privateKey: TEST_PRIVATE_KEY,
+  sessionSecret: 'a-secret-that-is-at-least-32-characters-long',
+};
+
+const NOW = new Date('2026-06-01T12:00:00Z');
+
+function json(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+function makeProvider(
+  responses: Array<() => Response>,
+  options: { now?: () => Date } = {},
+) {
+  const calls: Array<{ url: string; init: RequestInit }> = [];
+  let index = 0;
+
+  const fetchImpl = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+    calls.push({ url: String(url), init: init ?? {} });
+    const respond = responses[Math.min(index, responses.length - 1)];
+    index += 1;
+    if (respond === undefined) throw new Error('no response configured');
+    return respond();
+  }) as unknown as typeof fetch;
+
+  const provider = new InstallationTokenProvider(CONFIG, {
+    fetchImpl,
+    now: options.now ?? (() => NOW),
+  });
+
+  return { provider, calls, fetchImpl };
+}
+
+const tokenResponse =
+  (token = 'ghs_installationtoken', minutes = 60) =>
+  () =>
+    json({
+      token,
+      expires_at: new Date(NOW.getTime() + minutes * 60_000).toISOString(),
+    });
+
+describe('InstallationTokenProvider.getToken', () => {
+  it('mints a token for an installation', async () => {
+    const { provider, calls } = makeProvider([tokenResponse()]);
+    const result = await provider.getToken(42);
+
+    expect(result.token).toBe('ghs_installationtoken');
+    expect(calls[0]?.url).toBe(
+      'https://api.github.com/app/installations/42/access_tokens',
+    );
+    expect(calls[0]?.init.method).toBe('POST');
+  });
+
+  it('authenticates the mint request with the App JWT, not a static secret', async () => {
+    const { provider, calls } = makeProvider([tokenResponse()]);
+    await provider.getToken(42);
+
+    const auth = String(new Headers(calls[0]?.init.headers).get('authorization'));
+    expect(auth.startsWith('Bearer ')).toBe(true);
+    // A JWT, not the client secret.
+    expect(auth.split('.')).toHaveLength(3);
+    expect(auth).not.toContain('test-client-secret');
+  });
+
+  it('reuses a cached token rather than minting per request', async () => {
+    // One analysis makes ~22 requests; minting per request would be absurd.
+    const { provider, fetchImpl } = makeProvider([tokenResponse()]);
+
+    await provider.getToken(42);
+    await provider.getToken(42);
+    await provider.getToken(42);
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps installations separate', async () => {
+    const { provider, fetchImpl } = makeProvider([
+      tokenResponse('token-a'),
+      tokenResponse('token-b'),
+    ]);
+
+    const a = await provider.getToken(1);
+    const b = await provider.getToken(2);
+
+    expect(a.token).toBe('token-a');
+    expect(b.token).toBe('token-b');
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it('refreshes before expiry rather than after a failure', async () => {
+    // A token that expires mid-analysis would fail requests that had already
+    // been budgeted for. The margin avoids ever finding out.
+    let clock = NOW;
+    const { provider, fetchImpl } = makeProvider(
+      [tokenResponse('first', 60), tokenResponse('second', 60)],
+      { now: () => clock },
+    );
+
+    await provider.getToken(42);
+    // 56 minutes later: 4 minutes of life left, inside the 5-minute margin.
+    clock = new Date(NOW.getTime() + 56 * 60_000);
+    const refreshed = await provider.getToken(42);
+
+    expect(refreshed.token).toBe('second');
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it('still uses a cached token comfortably before the margin', async () => {
+    let clock = NOW;
+    const { provider, fetchImpl } = makeProvider([tokenResponse('first', 60)], {
+      now: () => clock,
+    });
+
+    await provider.getToken(42);
+    clock = new Date(NOW.getTime() + 30 * 60_000);
+    await provider.getToken(42);
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports a revoked installation distinctly', async () => {
+    // The normal signal that a user removed the App.
+    const { provider } = makeProvider([() => json({ message: 'Not Found' }, 404)]);
+
+    await expect(provider.getToken(42)).rejects.toMatchObject({
+      reason: 'installation_unavailable',
+    });
+  });
+
+  it('drops the cached token when an installation goes away', async () => {
+    const { provider, fetchImpl } = makeProvider([
+      tokenResponse('good'),
+      () => json({ message: 'Not Found' }, 404),
+      tokenResponse('new'),
+    ]);
+
+    await provider.getToken(42);
+    await provider.getToken(42).catch(() => {});
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+
+    provider.invalidate(42);
+    await provider.getToken(42).catch(() => {});
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it('rejects a malformed token response rather than caching nonsense', async () => {
+    const { provider } = makeProvider([() => json({ token: 12345 })]);
+    await expect(provider.getToken(42)).rejects.toMatchObject({
+      reason: 'exchange_failed',
+    });
+  });
+
+  it('rejects an unreadable expiry', async () => {
+    const { provider } = makeProvider([
+      () => json({ token: 'ghs_x', expires_at: 'not-a-date' }),
+    ]);
+    await expect(provider.getToken(42)).rejects.toMatchObject({
+      reason: 'exchange_failed',
+    });
+  });
+});
+
+describe('InstallationTokenProvider.listRepositories', () => {
+  it('lists what the installation actually grants', async () => {
+    const { provider } = makeProvider([
+      tokenResponse(),
+      () =>
+        json({
+          repositories: [
+            { id: 2, full_name: 'acme/private-service', private: true },
+            { id: 1, full_name: 'acme/public-lib', private: false },
+          ],
+        }),
+    ]);
+
+    const repositories = await provider.listRepositories(42);
+
+    // Sorted by full name: "private-service" precedes "public-lib".
+    expect(repositories).toEqual([
+      { githubId: 2, fullName: 'acme/private-service', isPrivate: true },
+      { githubId: 1, fullName: 'acme/public-lib', isPrivate: false },
+    ]);
+  });
+
+  it('uses the installation token, not the App JWT', async () => {
+    const { provider, calls } = makeProvider([
+      tokenResponse('ghs_scoped'),
+      () => json({ repositories: [] }),
+    ]);
+
+    await provider.listRepositories(42);
+
+    expect(new Headers(calls[1]?.init.headers).get('authorization')).toBe(
+      'Bearer ghs_scoped',
+    );
+  });
+
+  it('skips records missing the fields it depends on', async () => {
+    const { provider } = makeProvider([
+      tokenResponse(),
+      () =>
+        json({
+          repositories: [
+            { id: 1, full_name: 'acme/ok', private: false },
+            { full_name: 'acme/no-id' },
+            { id: 3 },
+          ],
+        }),
+    ]);
+
+    expect(await provider.listRepositories(42)).toHaveLength(1);
+  });
+
+  it('reports a revoked installation while listing', async () => {
+    const { provider } = makeProvider([
+      tokenResponse(),
+      () => json({ message: 'Not Found' }, 404),
+    ]);
+
+    await expect(provider.listRepositories(42)).rejects.toMatchObject({
+      reason: 'installation_unavailable',
+    });
+  });
+});

--- a/tests/unit/auth/session.test.ts
+++ b/tests/unit/auth/session.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  SESSION_COOKIE,
+  type SessionData,
+  sealSession,
+  sessionCookieOptions,
+  unsealSession,
+} from '@/lib/auth/session';
+
+const SECRET = 'a-secret-that-is-at-least-32-characters-long';
+const OTHER_SECRET = 'a-different-secret-also-32-characters-long!!';
+const NOW = new Date('2026-06-01T12:00:00Z');
+
+function session(overrides: Partial<SessionData> = {}): SessionData {
+  return {
+    installationId: 12345,
+    login: 'acme',
+    expiresAt: Math.floor(NOW.getTime() / 1000) + 3600,
+    ...overrides,
+  };
+}
+
+describe('sealSession / unsealSession', () => {
+  it('round-trips a session', () => {
+    const sealed = sealSession(session(), SECRET);
+    expect(unsealSession(sealed, SECRET, NOW)).toEqual(session());
+  });
+
+  it('produces an opaque value that does not leak its contents', () => {
+    const sealed = sealSession(session({ login: 'acme-corp' }), SECRET);
+    expect(sealed).not.toContain('acme-corp');
+    expect(sealed).not.toContain('12345');
+  });
+
+  it('produces a different ciphertext each time, so cookies are not comparable', () => {
+    // A fresh IV per seal. Identical sessions must not produce identical
+    // cookies, or an observer could tell two users hold the same session.
+    const first = sealSession(session(), SECRET);
+    const second = sealSession(session(), SECRET);
+    expect(first).not.toBe(second);
+    expect(unsealSession(first, SECRET, NOW)).toEqual(unsealSession(second, SECRET, NOW));
+  });
+
+  it('rejects a session sealed with a different secret', () => {
+    const sealed = sealSession(session(), OTHER_SECRET);
+    expect(unsealSession(sealed, SECRET, NOW)).toBeNull();
+  });
+
+  it('rejects a tampered payload rather than trusting it', () => {
+    // AES-GCM authenticates as well as encrypts, so flipping any byte fails
+    // the tag check rather than decrypting to something plausible.
+    const sealed = sealSession(session(), SECRET);
+    const raw = Buffer.from(sealed, 'base64url');
+    const last = raw.length - 1;
+    raw[last] = (raw[last] ?? 0) ^ 0xff;
+
+    expect(unsealSession(raw.toString('base64url'), SECRET, NOW)).toBeNull();
+  });
+
+  it('rejects an expired session', () => {
+    const sealed = sealSession(
+      session({ expiresAt: Math.floor(NOW.getTime() / 1000) - 1 }),
+      SECRET,
+    );
+    expect(unsealSession(sealed, SECRET, NOW)).toBeNull();
+  });
+
+  it('accepts a session that has not quite expired', () => {
+    const sealed = sealSession(
+      session({ expiresAt: Math.floor(NOW.getTime() / 1000) + 1 }),
+      SECRET,
+    );
+    expect(unsealSession(sealed, SECRET, NOW)).not.toBeNull();
+  });
+
+  it.each([
+    ['empty', ''],
+    ['not base64', '!!!not-base64!!!'],
+    ['too short to contain an IV and tag', 'AAAA'],
+    ['random bytes', Buffer.from('x'.repeat(64)).toString('base64url')],
+  ])('returns null for a %s cookie', (_label, value) => {
+    expect(unsealSession(value, SECRET, NOW)).toBeNull();
+  });
+
+  it('refuses to seal with a secret that is too short to be safe', () => {
+    expect(() => sealSession(session(), 'too-short')).toThrow(/at least 32/);
+  });
+
+  it('treats a too-short secret as signed out rather than throwing on read', () => {
+    // A misconfigured deployment should log people out, not 500 on every page.
+    expect(unsealSession('anything', 'too-short', NOW)).toBeNull();
+  });
+
+  it('does not carry a GitHub token in the session at all', () => {
+    // The session holds an installation id; tokens are minted server-side.
+    // A stolen cookie must not be a stolen credential.
+    const data = session();
+    expect(Object.keys(data)).toEqual(['installationId', 'login', 'expiresAt']);
+    expect(JSON.stringify(data)).not.toMatch(/token/i);
+  });
+});
+
+describe('sessionCookieOptions', () => {
+  it('is HttpOnly and SameSite=Lax', () => {
+    const options = sessionCookieOptions(3600);
+    expect(options.httpOnly).toBe(true);
+    expect(options.sameSite).toBe('lax');
+    expect(options.path).toBe('/');
+    expect(options.maxAge).toBe(3600);
+  });
+
+  it('names the cookie consistently', () => {
+    expect(SESSION_COOKIE).toBe('reposignal_session');
+  });
+});


### PR DESCRIPTION
## Summary

Sign in with GitHub so a team can analyze their own private repositories — the largest remaining gap in the product.

Closes #52

## Why a GitHub App, not "Sign in with GitHub"

A classic OAuth App needs the `repo` scope. That grants **read *and write*** access to every repository the user can reach, including ones they never intended to analyze.

| | OAuth App (`repo`) | GitHub App |
| --- | --- | --- |
| Repositories reachable | All of them | Only those the user selects |
| Write access | Yes | No |
| Revocable per repository | No | Yes |
| Credential lifetime | Until revoked | One hour |

Asking for write access to someone's entire account in order to render a read-only report would contradict everything else this project does about least privilege.

## Credential handling

**The session cookie contains no GitHub token.** It holds an installation id, a display name, and an expiry, sealed with AES-256-GCM — so a tampered cookie fails to *decrypt* rather than merely failing a comparison. A stolen cookie is not a stolen credential.

Installation tokens are minted per use from the App private key, cached behind a five-minute refresh margin so one never expires mid-analysis, and never written to the database or a log.

The App JWT is signed with `node:crypto` rather than a JWT library — one token, one algorithm, and a dependency that can verify *arbitrary* tokens is a larger surface than the twenty lines it replaces. The signature is verified cryptographically in tests against a generated public key, not asserted by shape.

## Three isolation properties, each asserted by test

1. **Authorization is re-checked against GitHub, not trusted from the session.** Before every private analysis, RepoSignal asks GitHub which repositories the installation grants. Typing the path of a repository you did not grant produces the same not-found a stranger gets — and revoking on GitHub takes effect on the next analysis.

2. **Private analyses never touch the shared cache.** That cache is keyed on repository identity alone, so a cached private result would be readable by anyone naming the repository. Skipped in both directions.

3. **Deduplication is keyed on the installation.** Two sessions asking for the same private repository cannot share one in-flight analysis, which would hand the second session the first's access.

`state` is compared in constant time and consumed whether or not it matches, so it cannot be replayed.

## Optional by design

With no App configured there is no sign-in link and the public analyzer is untouched. A **partial** configuration is rejected rather than half-enabling the feature.

## Verified locally

| Path | Result |
| --- | --- |
| No App configured | No sign-in link; public analysis unaffected; `/auth/sign-in` redirects away |
| App configured | Sign-in link appears; redirects to GitHub with a state cookie |
| Callback, no state cookie | Rejected — `sign_in_failed reason=state_mismatch` |
| Callback, mismatched state | Rejected — `sign_in_failed reason=state_mismatch` |
| Callback, forged `installation_id` | Rejected — `sign_in_failed reason=installation_unavailable` |

That last one matters: `installation_id` arrives in the query string, and minting a token against it is what stops a crafted value producing a session for someone else's installation.

## Testing

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test` — **544 passing** (up from 477)
- [x] `npm run build`

```
File       | % Stmts | % Branch | % Funcs | % Lines
-----------|---------|----------|---------|--------
All files  |   95.94 |    89.55 |   96.41 |   97.23
 lib/auth  |   96.69 |    90.47 |     100 |     100
```

The test RSA key is **generated at import time**, not committed. A PEM private key checked into a repository is indistinguishable from a leaked one at a glance, and every secret scanner will flag it.

## Risks

**This has not been exercised against a real GitHub App.** Creating one requires GitHub's web UI and cannot be automated. The logic below the handshake is covered — JWT signing verified cryptographically, session sealing tested for tampering and expiry, the flow driven end to end with a mocked GitHub — but the first person to complete the setup is doing the live verification. `docs/PRIVATE_REPOSITORIES.md` says exactly that rather than implying it is proven.

Sign-out clears RepoSignal's session only; it does not uninstall the App. The UI says so and links to GitHub.

## Checklist

- [x] Scope matches the linked issue
- [x] Tests cover the new behavior, including the isolation and rejection paths
- [x] No scoring rules changed, so no version bump required
- [x] **No secrets committed** — verified by scanning the diff; the only key-shaped string is an `abc` placeholder in a config test
- [x] Documentation updated (README, docs/PRIVATE_REPOSITORIES.md, .env.example, CHANGELOG)