### PR TITLE
feat(normalize): recognize lockfiles from eighteen more ecosystems

### DIFF
--- a/src/lib/normalize/snapshot.ts
+++ b/src/lib/normalize/snapshot.ts
@@ -59,7 +59,42 @@ const LOCKFILES = new Set([
   'mix.lock',
   'pubspec.lock',
   'gradle.lockfile',
+
+  // npm again: `npm shrinkwrap` writes this instead of package-lock.json, and
+  // a package published with one had been reading as having no lockfile at all.
+  'npm-shrinkwrap.json',
+
+  // Apple
+  'package.resolved', // SwiftPM
+  'podfile.lock', // CocoaPods
+  'cartfile.resolved', // Carthage
+
+  // Haskell — the two build tools each have their own
+  'cabal.project.freeze', // cabal freeze
+  'stack.yaml.lock', // Stack
+
+  'manifest.toml', // Julia (Manifest.toml); Gleam uses the same name lowercased
+  'renv.lock', // R, renv
+  'conan.lock', // C/C++, Conan
+  'deno.lock', // Deno
+  'shard.lock', // Crystal, Shards
+  'nimble.lock', // Nim, Nimble
+  'cpanfile.snapshot', // Perl, Carton
+  'conda-lock.yml', // conda-lock
+
+  // Infrastructure and build systems. A repository is scored on whether it
+  // pins what it depends on; a Terraform provider or a Helm chart is a
+  // dependency in exactly that sense.
+  'flake.lock', // Nix flakes
+  '.terraform.lock.hcl', // Terraform providers
+  'chart.lock', // Helm
+  'module.bazel.lock', // Bazel, bzlmod
 ]);
+
+// Deliberately absent: Elm. `elm.json` records version *ranges*, not resolved
+// versions, and `elm-stuff/` is a build cache rather than a manifest — the
+// language ships no lockfile, so counting either would score a repository for
+// something it cannot have.
 
 /**
  * Workflow steps that indicate security scanning.

--- a/tests/unit/normalize/snapshot.test.ts
+++ b/tests/unit/normalize/snapshot.test.ts
@@ -452,8 +452,44 @@ describe('detectLockfiles', () => {
     ['go', 'go.sum'],
     ['bundler', 'Gemfile.lock'],
     ['composer', 'composer.lock'],
+    // Each of these is its ecosystem's canonical resolved-version file; the
+    // documentation for each is linked in the PR that added it.
+    ['npm shrinkwrap', 'npm-shrinkwrap.json'],
+    ['SwiftPM', 'Package.resolved'],
+    ['CocoaPods', 'Podfile.lock'],
+    ['Carthage', 'Cartfile.resolved'],
+    ['cabal', 'cabal.project.freeze'],
+    ['Stack', 'stack.yaml.lock'],
+    ['Julia', 'Manifest.toml'],
+    ['renv', 'renv.lock'],
+    ['Conan', 'conan.lock'],
+    ['Deno', 'deno.lock'],
+    ['Crystal', 'shard.lock'],
+    ['Nimble', 'nimble.lock'],
+    ['Carton', 'cpanfile.snapshot'],
+    ['conda-lock', 'conda-lock.yml'],
+    ['Nix flakes', 'flake.lock'],
+    ['Terraform', '.terraform.lock.hcl'],
+    ['Helm', 'Chart.lock'],
+    ['Bazel', 'MODULE.bazel.lock'],
   ])('detects the %s lockfile', (_label, name) => {
     expect(detectLockfiles([file(name)])).toEqual([name]);
+  });
+
+  it('matches case-insensitively but reports the name as written', () => {
+    // Julia writes Manifest.toml, Gleam writes manifest.toml, and a Windows
+    // checkout can produce either. The reported name is the repository's.
+    expect(detectLockfiles([file('MANIFEST.TOML')])).toEqual(['MANIFEST.TOML']);
+    expect(detectLockfiles([file('manifest.toml')])).toEqual(['manifest.toml']);
+    expect(detectLockfiles([file('Package.Resolved')])).toEqual(['Package.Resolved']);
+  });
+
+  it('does not count Elm, which has no lockfile', () => {
+    // elm.json records version ranges, not resolved versions, and elm-stuff is
+    // a build cache. Counting either would credit a repository for a file that
+    // cannot exist.
+    expect(detectLockfiles([file('elm.json')])).toEqual([]);
+    expect(detectLockfiles([file('elm-stuff', 0, 'dir')])).toEqual([]);
   });
 
   it('ignores non-lockfiles', () => {
@@ -462,6 +498,25 @@ describe('detectLockfiles', () => {
 
   it('ignores a directory that shares a lockfile name', () => {
     expect(detectLockfiles([file('go.sum', 0, 'dir')])).toEqual([]);
+  });
+
+  it('ignores a directory sharing a newly added lockfile name', () => {
+    // `Package.resolved` and `flake.lock` are plausible directory names in a
+    // vendored checkout, so the type guard has to hold for the additions too.
+    for (const name of ['Package.resolved', 'flake.lock', 'Manifest.toml']) {
+      expect(detectLockfiles([file(name, 0, 'dir')])).toEqual([]);
+    }
+  });
+
+  it('reports every lockfile in a polyglot repository', () => {
+    expect(
+      detectLockfiles([
+        file('package-lock.json'),
+        file('Cargo.lock'),
+        file('flake.lock'),
+        file('README.md'),
+      ]),
+    ).toEqual(['package-lock.json', 'Cargo.lock', 'flake.lock']);
   });
 });
 


### PR DESCRIPTION
Closes #42

18 additions to `LOCKFILES`, one test case each, plus the case-insensitivity and directory guards.

## Every addition, with its documentation

| Ecosystem | File | Canonical because |
| --- | --- | --- |
| npm | `npm-shrinkwrap.json` | [`npm shrinkwrap`](https://docs.npmjs.com/cli/v10/commands/npm-shrinkwrap) writes this *instead of* `package-lock.json` |
| SwiftPM | `Package.resolved` | [Swift Package Manager docs](https://developer.apple.com/documentation/xcode/identifying-binary-dependencies) — pinned resolved versions |
| CocoaPods | `Podfile.lock` | [CocoaPods guide](https://guides.cocoapods.org/using/using-cocoapods.html#what-is-a-podfilelock) |
| Carthage | `Cartfile.resolved` | [Carthage docs](https://github.com/Carthage/Carthage/blob/master/Documentation/Artifacts.md#cartfileresolved) |
| Haskell (cabal) | `cabal.project.freeze` | [`cabal freeze`](https://cabal.readthedocs.io/en/stable/cabal-project.html#cfg-flag---freeze) |
| Haskell (Stack) | `stack.yaml.lock` | [Stack lock files](https://docs.haskellstack.org/en/stable/lock_files/) |
| Julia | `Manifest.toml` | [Pkg.jl](https://pkgdocs.julialang.org/v1/toml-files/#Manifest.toml) — `Project.toml` is the manifest, `Manifest.toml` is the lock |
| R | `renv.lock` | [renv docs](https://rstudio.github.io/renv/articles/lockfile.html) |
| Conan | `conan.lock` | [Conan lockfiles](https://docs.conan.io/2/tutorial/versioning/lockfiles.html) |
| Deno | `deno.lock` | [Deno integrity checking](https://docs.deno.com/runtime/fundamentals/modules/#integrity-checking-and-lock-files) |
| Crystal | `shard.lock` | [Shards](https://github.com/crystal-lang/shards/blob/master/docs/shard.yml.adoc) |
| Nim | `nimble.lock` | [Nimble lock files](https://github.com/nim-lang/nimble#nimble-lock) |
| Perl | `cpanfile.snapshot` | [Carton](https://metacpan.org/pod/Carton) |
| conda | `conda-lock.yml` | [conda-lock](https://conda.github.io/conda-lock/) |
| Nix | `flake.lock` | [Nix flakes](https://nix.dev/concepts/flakes.html) |
| Terraform | `.terraform.lock.hcl` | [Dependency lock file](https://developer.hashicorp.com/terraform/language/files/dependency-lock) |
| Helm | `Chart.lock` | [Helm dependencies](https://helm.sh/docs/helm/helm_dependency/) |
| Bazel | `MODULE.bazel.lock` | [Bzlmod lockfile](https://bazel.build/external/lockfile) |

Two notes on the table:

**`npm-shrinkwrap.json` was a gap inside an already-supported ecosystem** — a package published with a shrinkwrap was reading as having no lockfile at all. Worth having independently of the rest.

**`Manifest.toml` covers Gleam too**, which uses the same name lowercased. Matching is case-insensitive, so one entry serves both.

## What I deliberately did not add

**Elm.** Your instinct in the issue was right: `elm.json` records version *ranges*, not resolved versions, and `elm-stuff/` is a build cache. Elm ships no lockfile, so counting either would credit a repository for a file it cannot have. There is a test asserting both are ignored, so the reasoning survives as a decision rather than as an omission.

I also left out sbt (`build.sbt.lock` comes from a third-party plugin, not the tool) and opam (its lock files are named `<package>.opam.locked`, so a filename set cannot match them) — both would need the ecosystem inference the issue puts out of scope.

## Tests

Extended the existing `describe('detectLockfiles')` table, as suggested — no new file. Beyond one row per addition:

- `matches case-insensitively but reports the name as written` — covers `MANIFEST.TOML` / `manifest.toml` / `Package.Resolved`, and pins that the *reported* name is the repository's, not the folded key
- `does not count Elm, which has no lockfile`
- `ignores a directory sharing a newly added lockfile name` — the existing guard only covered `go.sum`; `Package.resolved`, `flake.lock` and `Manifest.toml` are all plausible directory names in a vendored checkout
- `reports every lockfile in a polyglot repository`

Nothing outside the set changed: no content parsing, no ecosystem inference.

## Verification

`npm test` — 499 pass across 13 files. `npm run lint` — clean.

`npx tsc --noEmit` reports three `LayoutProps` / `PageProps` errors in `src/app/`, which are Next.js generated types unrelated to this change and present before it.
